### PR TITLE
Fix typo in Base Type Builder docs

### DIFF
--- a/docs/builder.md
+++ b/docs/builder.md
@@ -139,7 +139,7 @@ const field = new BaseBuilder()
 
 **error**: `(value, path, context) => ?(string | ReactElement)`
 
-## `setValidationErrorMessageFn(error)`
+## `addValidationErrorMessageFn(error)`
 
 ### Summary
 


### PR DESCRIPTION
Change `setValidationErrorMessageFn` to `addValidationErrorMessageFn`