### PR TITLE
Create StructBuilder, setConfig helper methods

### DIFF
--- a/docs/builder.md
+++ b/docs/builder.md
@@ -329,6 +329,17 @@ pass-through for setting props on the underlying template.
 
 **config**: `object`
 
+## `setTheme(config)`
+
+### Summary
+
+Set the theme in the config object for this type. It is the responsibility
+of the template to handle styling.
+
+### Parameters
+
+**theme**: `string`
+
 ## `_disableTemplates()`
 
 ### Summary

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcomb-builder",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A declarative syntax for building Tcomb type and options objects",
   "main": "dist/index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcomb-builder",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A declarative syntax for building Tcomb type and options objects",
   "main": "dist/index.js",
   "license": "Apache-2.0",

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -317,6 +317,16 @@ export default class BaseBuilder {
   }
 
   /**
+   * HELPER: Sets the theme in the config blob.
+   *
+   * @param {string} theme
+   * @return {Builder}
+   */
+  setTheme(theme) {
+    return this.setConfig({ theme });
+  }
+
+  /**
    * Return a realized type. Lazily realize the type so that the most recent
    * versions of the `error` function and `_fieldBuilders` object are
    * available.

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -57,6 +57,15 @@ describe('BaseBuilder', () => {
       });
     });
 
+    describe('setTheme()', () => {
+      it('can set theme options to the field\'s config option', () => {
+        const theme = 'light';
+        const builder = new BaseBuilder().setTheme(theme);
+
+        expect(builder.getOptions().config).to.deep.equal({ theme: 'light' });
+      });
+    });
+
     describe('setValue()', () => {
       it('can set a label option field', () => {
         const builder = new BaseBuilder().setValue('foobar');

--- a/src/primitives/StructBuilder.js
+++ b/src/primitives/StructBuilder.js
@@ -1,7 +1,31 @@
 import tcomb from 'tcomb-validation';
 
-import { validation } from '../combinators';
 import BaseBuilder from '../BaseBuilder';
+import { validation } from '../combinators';
 
-export default new BaseBuilder()
+
+class StructBuilder extends BaseBuilder {
+  /**
+   * Set the number of columns in the config blob. This
+   * only affects how the form gets displayed.
+   *
+   * @param {integer} columns
+   */
+  setColumns(columns) {
+    return this.setConfig({ columns });
+  }
+
+  /**
+   * Set the vertical rhythm in the config blob. The template should
+   * use this to configure how much vertical spacing should be between
+   * each individual component.
+   *
+   * @param {number} rhythm
+   */
+  setVerticalRhythm(rhythm) {
+    return this.setConfig({ rhythm });
+  }
+}
+
+export default new StructBuilder()
   .setType((errorFn = () => {}, fields) => validation(tcomb.struct(fields), errorFn, 'Struct'));

--- a/src/primitives/__tests__/StructBuilder.spec.js
+++ b/src/primitives/__tests__/StructBuilder.spec.js
@@ -29,4 +29,22 @@ describe('StructBuilder', () => {
     expect(actual.fields.second.label).to.equal(expected.fields.second.label);
     expect(actual.order).to.deep.equal(expected.order);
   });
+
+  describe('setVerticalRhythm()', () => {
+    it('can set rhythm option to the field\'s config option', () => {
+      const rhythm = 20;
+      const builder = StructBuilder.setVerticalRhythm(rhythm);
+
+      expect(builder.getOptions().config).to.deep.equal({ rhythm: 20 });
+    });
+  });
+
+  describe('setColumns()', () => {
+    it('can set columns option to the field\'s config option', () => {
+      const columns = 2;
+      const builder = StructBuilder.setColumns(columns);
+
+      expect(builder.getOptions().config).to.deep.equal({ columns: 2 });
+    });
+  });
 });

--- a/src/templates/LazyTemplateProvider.js
+++ b/src/templates/LazyTemplateProvider.js
@@ -2,10 +2,11 @@ import Immutable from 'immutable';
 
 // Structs
 const CHECKBOX_GROUP = 'checkbox group';
-const SINGLE_COLUMN = 'single column';
 const DOUBLE_COLUMN = 'double column';
 const FORM_PAGE = 'form page';
+const SINGLE_COLUMN = 'single column';
 const STATIC_PAGE = 'static page';
+const STRUCT = 'struct';
 
 // Components
 const CHECKBOX = 'checkbox';
@@ -46,6 +47,7 @@ export default class LazyTemplateProvider {
   getRadio() { return this._getField(RADIO); }
   getSingleColumn() { return this._getField(SINGLE_COLUMN); }
   getStaticPage() { return this._getField(STATIC_PAGE); }
+  getStruct() { return this._getField(STRUCT); }
   getTextArea() { return this._getField(TEXT_AREA); }
   getTextField() { return this._getField(TEXT_FIELD); }
   getVerticalRadio() { return this._getField(VERTICAL_RADIO); }
@@ -59,6 +61,7 @@ export default class LazyTemplateProvider {
   setRadio(factory) { return this._setField(RADIO, factory); }
   setSingleColumn(factory) { return this._setField(SINGLE_COLUMN, factory); }
   setStaticPage(factory) { return this._setField(STATIC_PAGE, factory); }
+  setStruct(factory) { return this._setField(STRUCT, factory); }
   setTextField(factory) { return this._setField(TEXT_FIELD, factory); }
   setTextArea(factory) { return this._setField(TEXT_AREA, factory); }
   setVerticalRadio(factory) { return this._setField(VERTICAL_RADIO, factory); }

--- a/src/widgets/StructBuilder.js
+++ b/src/widgets/StructBuilder.js
@@ -1,0 +1,27 @@
+import BaseBuilder from '../BaseBuilder';
+
+class StructBuilder extends BaseBuilder {
+  /**
+   * Set the number of columns in the config blob. This
+   * only affects how the form gets displayed.
+   *
+   * @param {integer} columns
+   */
+  setColumns(columns) {
+    return this.setConfig({ columns });
+  }
+
+  /**
+   * Set the vertical rhythm in the config blob. The template should
+   * use this to configure how much vertical spacing should be between
+   * each individual component.
+   *
+   * @param {number} rhythm
+   */
+  setVerticalRhythm(rhythm) {
+    return this.setConfig({ rhythm });
+  }
+}
+
+export default new StructBuilder()
+  .setLazyTemplateFactory(provider => provider.getStruct());

--- a/src/widgets/StructBuilder.js
+++ b/src/widgets/StructBuilder.js
@@ -1,27 +1,5 @@
-import BaseBuilder from '../BaseBuilder';
+import StructBuilder from '../primitives/StructBuilder';
 
-class StructBuilder extends BaseBuilder {
-  /**
-   * Set the number of columns in the config blob. This
-   * only affects how the form gets displayed.
-   *
-   * @param {integer} columns
-   */
-  setColumns(columns) {
-    return this.setConfig({ columns });
-  }
-
-  /**
-   * Set the vertical rhythm in the config blob. The template should
-   * use this to configure how much vertical spacing should be between
-   * each individual component.
-   *
-   * @param {number} rhythm
-   */
-  setVerticalRhythm(rhythm) {
-    return this.setConfig({ rhythm });
-  }
-}
-
-export default new StructBuilder()
+export default StructBuilder
   .setLazyTemplateFactory(provider => provider.getStruct());
+

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -4,5 +4,6 @@ export DropDownBuilder from './DropDownBuilder';
 export NumberBuilder from './NumberBuilder';
 export RadioBuilder from './RadioBuilder';
 export StaticPageBuilder from './StaticPageBuilder';
+export StructBuilder from './StructBuilder';
 export TextAreaBuilder from './TextAreaBuilder';
 export TextBuilder from './TextBuilder';


### PR DESCRIPTION
## New
- StructBuilder is now a **widget**
  - Features:
    - `setVerticalRhythm`
      - This is a non-functional helper function. It creates a contract for us to set the spacing between components on the frontend.
    - `setColumns`
      - In an effort to consolidate some templates, we are going to store the number of columns in the options blob at the builder level, rather than having separate templates for each. This will allow the builder to become even more expressive and reduce some redundancies on the frontend.
- `setTheme`
  - A non-functional helper method that creates a contract with theming all of our components. We have started to use the following pattern on the frontend: `.setConfig({ theme: 'light' })`. This convenience function makes theme a first-class citizen for the builder.

Example:
```js
widgets.StructBuilder
    .setTheme('light')
    .setColumns(2)
    .setField('field1', widgets.TextBuilder)
    .setField('field2', widgets.TextBuilder);
```

## Changed
- `widgets.SingleColumnBuilder` and `widgets.DoubleColumnBuilder` are now deprecated in favor of `.setColumns()`