### PR TITLE
Unions: Correctly configure the options objects for tcomb-form to read

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcomb-builder",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A declarative syntax for building Tcomb type and options objects",
   "main": "dist/index.js",
   "license": "Apache-2.0",

--- a/src/primitives/__tests__/UnionBuilder.spec.js
+++ b/src/primitives/__tests__/UnionBuilder.spec.js
@@ -20,6 +20,38 @@ describe('UnionBuilder', () => {
       expect(() => Country({ country: 'usa' })).to.throw();
       expect(() => Country({ country: 'canada' })).to.not.throw();
     });
+
+    it('returns an array of options objects', () => {
+      const international = StructBuilder
+        .setField('country', TextBuilder);
+      const usa = StructBuilder
+        .setField('country', TextBuilder)
+        .setField('state', TextBuilder);
+      const countriesBuilder = UnionBuilder
+        .setUnion([international, usa])
+        .setDispatch(value => (
+          value.country === 'usa' ? usa : international
+        ));
+      expect(countriesBuilder.getOptions()).to.have.length(2);
+    });
+
+    it('dispatch must return instance of type from union', () => {
+      const international = StructBuilder
+        .setField('country', TextBuilder);
+      const usa = StructBuilder
+        .setField('country', TextBuilder)
+        .setField('state', TextBuilder);
+      const imposterUsa = StructBuilder
+        .setField('country', TextBuilder)
+        .setField('state', TextBuilder);
+      const countriesBuilder = UnionBuilder
+        .setUnion([international, usa])
+        .setDispatch(value => (
+          value.country === 'usa' ? imposterUsa : international
+        ));
+      const Country = countriesBuilder.getType();
+      expect(() => Country({ country: 'usa', state: 'california' })).to.throw();
+    });
   });
 
   describe('setField', () => {


### PR DESCRIPTION
This PR contains 2 fixes:
- Tcomb-Form expects an array of `options` to be returned for a UnionType.
- The dispatch function must return an instance of an type. `builder1.getType() !== builder1.getType()`.