### PR TITLE
Error and label template callbacks

### DIFF
--- a/docs/builder.md
+++ b/docs/builder.md
@@ -115,6 +115,21 @@ factory by passing a callback function to the `setLazyTemplateFactory` method.
 
 **factory**: `LazyTemplateInterface => TemplateFactory`
 
+## `setErrorMessageTemplate(callback)`
+
+### Summary
+
+Set a template callback that is used by the field's template to render the
+error message.
+
+### Example
+
+`.setErrorMessageTemplate(error => <span>{error}</span>)`
+
+### Parameters
+
+**callback**: `string => ReactElement|HTMLElement`
+
 ## `setValidationErrorMessageFn(error)`
 
 ### Summary

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -122,6 +122,28 @@ export default class BaseBuilder {
   }
 
   /**
+   * Set the `errorTemplateCallback` function which will be used to
+   * render the error message for the field.
+   *
+   * @param {String => ReactNode} errorTemplateCallback
+   * @return {Builder}
+   */
+  setErrorMessageTemplate(errorTemplateCallback) {
+    return this.setConfig({ errorTemplateCallback });
+  }
+
+  /**
+   * Set the `labelTemplateCallback` function which will be used to
+   * render the label for the field.
+   *
+   * @param {String => ReactNode} labelTemplateCallback
+   * @return {Builder}
+   */
+  setLabelTemplate(labelTemplateCallback) {
+    return this.setConfig({ labelTemplateCallback });
+  }
+
+  /**
    * Set the error message function in the options object for this type.
    * Override any existing errors.
    *

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -77,6 +77,24 @@ describe('BaseBuilder', () => {
       });
     });
 
+    describe('setErrorMessageTemplate()', () => {
+      it('can set setErrorMessageTemplate options to the field\'s config option', () => {
+        const errorTemplateCallback = error => `ERROR: ${error}`;
+        const builder = new BaseBuilder().setErrorMessageTemplate(errorTemplateCallback);
+
+        expect(builder.getOptions().config).to.deep.equal({ errorTemplateCallback });
+      });
+    });
+
+    describe('setLabelTemplate()', () => {
+      it('can set labelTemplateCallback options to the field\'s config option', () => {
+        const labelTemplateCallback = error => `Label: ${error}`;
+        const builder = new BaseBuilder().setLabelTemplate(labelTemplateCallback);
+
+        expect(builder.getOptions().config).to.deep.equal({ labelTemplateCallback });
+      });
+    });
+
     describe('setSort()', () => {
       it('can set sort option in the config', () => {
         const sortComparator = (a, b) => {


### PR DESCRIPTION
## Granular Templates

Customizing a form should be easier and more freeform. Currently, if you want to customize the look of a field, you have 2 options:
- Create a new theme (Affects styling of current template; template must support that theme)
- Create an entirely new template

This PR introduces another dimension of customization: Granular templating.
- Label Template
- Error Template

#### Error Message Template
```
  /**
   * Set the `errorTemplateCallback` function which will be used to
   * render the error message for the field.
   *
   * @param {String => ReactNode} errorTemplateCallback
   * @return {Builder}
   */
  setErrorMessageTemplate(errorTemplateCallback) { ... }
```

#### Label Template
```
  /**
   * Set the `labelTemplateCallback` function which will be used to
   * render the label for the field.
   *
   * @param {String => ReactNode} labelTemplateCallback
   * @return {Builder}
   */
  setLabelTemplate(labelTemplateCallback) { ... }
```