### PR TITLE
Shuffle and rename validation and error methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const validation = validators.text.nonEmpty;
 
 const TextBuilder = new BaseBuilder()
   .setTypeAndValidate(tcomb.String, 'Text')
-  .setValidationErrorMessageFn(validation);
+  .setValidation(validation);
 
 const name = TextBuilder.setLabel('Name');
 
@@ -121,7 +121,7 @@ import { primitives, validators, widgets } from '../index';
 const name = widgets.TextBuilder.setLabel('Name');
 
 const dateOfBirth = widgets.TextBuilder
-  .setValidationErrorMessageFn(validators.date.birthdate)
+  .setValidation(validators.date.birthdate)
   .setLabel('Date of Birth');
 
 const occupation = widgets.TextBuilder
@@ -144,7 +144,7 @@ const crossValidation = validators.combine([
 ]);
 
 const foodGroup = widgets.CheckboxGroupBuilder
-  .setValidationErrorMessageFn(crossValidation)
+  .setValidation(crossValidation)
   .setField('bananaStand', bananaStand)
   .setField('chickenDance', chickenDance)
   .setField('hugeMistake', hugeMistake)

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -132,13 +132,22 @@ factory by passing a callback function to the `setLazyTemplateFactory` method.
 
 Set the error key in the options object. Since the function set by
 `setValidation` runs client-side validation on the form, `setError` is best
-used to set errors returned by the API directly onto the form.
+used to set errors returned by the API directly onto the form. By default,
+`.setError` also sets hasError to true if `error` is truthy and false
+otherwise. You can disable this behavior by passing in the `autoHasError`
+option in the config object.
 
 ### Example
 
 ```js
 const field = new BaseBuilder()
     .setError('There was an error.');
+
+// or
+
+const field = new BaseBuilder()
+    .setError('There was an error.', { autoHasError: false })
+    .setHasError(someOtherBooleanTest);
 ```
 
 ### Parameters
@@ -152,13 +161,15 @@ const field = new BaseBuilder()
 Set the hasError key in the options object. Used in conjuction with setError to
 force tcomb to display an error. Setting hasError to true won't stop the form
 from being submitted; in fact, it will get overwritten by tcomb-form on submit.
+The default behavior of `.setError` is to set `hasError` to true if `error` is
+truthy and false otherwise, so only use this function in special cases.
 
 ### Example
 
 ```js
 const field = new BaseBuilder()
     .setError('There was an API error.')
-    .setHasError(apiError || false);
+    .setHasError(!!apiError);
 ```
 
 ### Parameters

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -134,7 +134,7 @@ Set the error key in the options object. Since the function set by
 `setValidation` runs client-side validation on the form, `setError` is best
 used to set errors returned by the API directly onto the form. By default,
 `.setError` also sets hasError to true if `error` is truthy and false
-otherwise. You can disable this behavior by passing in the `autoHasError`
+otherwise. You can disable this behavior by passing in the `overrideHasError`
 option in the config object.
 
 ### Example
@@ -146,7 +146,7 @@ const field = new BaseBuilder()
 // or
 
 const field = new BaseBuilder()
-    .setError('There was an error.', { autoHasError: false })
+    .setError('There was an error.', { overrideHasError: true })
     .setHasError(someOtherBooleanTest);
 ```
 

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -145,6 +145,26 @@ const field = new BaseBuilder()
 
 **error**: `string`
 
+## `setHasError(hasError)`
+
+### Summary
+
+Set the hasError key in the options object. Used in conjuction with setError to
+force tcomb to display an error. Setting hasError to true won't stop the form
+from being submitted; in fact, it will get overwritten by tcomb-form on submit.
+
+### Example
+
+```js
+const field = new BaseBuilder()
+    .setError('There was an API error.')
+    .setHasError(apiError || false);
+```
+
+### Parameters
+
+**hasError**: `boolean`
+
 ## `setValidation(getValidationErrorMessage)`
 
 ### Summary

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -126,13 +126,32 @@ factory by passing a callback function to the `setLazyTemplateFactory` method.
 
 **factory**: `LazyTemplateInterface => TemplateFactory`
 
-## `setValidationErrorMessageFn(error)`
+## `setError(error)`
 
 ### Summary
 
-Set an error message function for this field in its options object. The error
-message function must conform to the same spec as that in `tcomb-validation`.
-It simply returns `null` if there is no error, and a `string` if an error
+Set the error key in the options object. Since the function set by
+`setValidation` runs client-side validation on the form, `setError` is best
+used to set errors returned by the API directly onto the form.
+
+### Example
+
+```js
+const field = new BaseBuilder()
+    .setError('There was an error.');
+```
+
+### Parameters
+
+**error**: `string`
+
+## `setValidation(getValidationErrorMessage)`
+
+### Summary
+
+Set a validation function for this field as a static function on its type. The
+validation function must conform to the same spec as that in `tcomb-validation`
+where it returns `null` if there is no error, and a `string` if an error
 occurred.
 
 ### Example
@@ -143,20 +162,20 @@ function getValidationErrorMessage(value) {
 }
 
 const field = new BaseBuilder()
-    .setValidationErrorMessageFn(getValidationErrorMessage);
+    .setValidation(getValidationErrorMessage);
 ```
 
 ### Parameters
 
-**error**: `(value, path, context) => ?(string | ReactElement)`
+**getValidationErrorMessage**: `(value, path, context) => ?(string | ReactElement)`
 
-## `addValidationErrorMessageFn(error)`
+## `addValidation(getValidationErrorMessage)`
 
 ### Summary
 
-Adds an error message function to the existing function in the options object
-for this type. If there are no errors already set, then it is equivalent to
-`setValidationErrorMessageFn`.
+Adds a validation function to the existing function in the options object for
+this type. If there is no existing validation function, then it is equivalent
+to `setValidation`.
 
 ### Example
 
@@ -170,13 +189,13 @@ function truthyValidation(value) {
 }
 
 const field = new BaseBuilder()
-    .setValidationErrorMessageFn(booleanValidation)
-    .addValidationErrorMessageFn(truthyValidation);
+    .setValidation(booleanValidation)
+    .addValidation(truthyValidation);
 ```
 
 ### Parameters
 
-**error**: `(value, path, context) => ?(string | ReactElement)`
+**getValidationErrorMessage**: `(value, path, context) => ?(string | ReactElement)`
 
 ## `setField(key, fieldBuilder)`
 
@@ -240,10 +259,10 @@ export default RadioBuilder
 
 ### Summary
 
-Set the tcomb type of this builder. Similarly to the error field, the type must
-be passed in as a callback function in order to allow for arbitrary ordering of
-builder commands. The error function and fields are provided to you when you
-are creating the type.
+Set the tcomb type of this builder. The type must be passed in as a callback
+function in order to allow for arbitrary ordering of builder commands. The
+validation function and fields are provided to you when you are creating the
+type.
 
 ### Example
 

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -18,7 +18,7 @@ When you import the `validators` object, you can use its string length validator
 import * as validators from './path/to/validators';
 import TextBuilder from './path/to/TextBuilder';
 
-const zipCode = TextBuilder.setValidationErrorMessageFn(validators.text.length(5));
+const zipCode = TextBuilder.setValidation(validators.text.length(5));
 ```
 
 A common need is to perform several different validations on a single field.
@@ -49,7 +49,7 @@ const crossValidation = validators.combine([
 ]);
 
 const foodGroup = widgets.CheckboxGroupBuilder
-    .setValidationErrorMessageFn(crossValidation)
+    .setValidation(crossValidation)
     .setField('bananaStand', bananaStand)
     .setField('chickenDance', chickenDance)
     .setField('hugeMistake', hugeMistake)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcomb-builder",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "A declarative syntax for building Tcomb type and options objects",
   "main": "dist/index.js",
   "license": "Apache-2.0",

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -152,6 +152,18 @@ export default class BaseBuilder {
   }
 
   /**
+   * Set the hasError key in the options object. Used to force tcomb to display
+   * an error. Setting hasError to true won't stop the form from being
+   * submitted; in fact, it will get overwritten by tcomb-form on submit.
+   *
+   * @param {boolean} hasError
+   * @return {BaseBuilder}
+   */
+  setHasError(hasError) {
+    return new this.constructor(this._state.mergeDeep({ options: { hasError } }));
+  }
+
+  /**
    * Set a validation function that will be set on the tcomb type when it is
    * realized. This method will override previously set functions.
    *

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -144,17 +144,15 @@ export default class BaseBuilder {
    * Set the error key in the options object. Used to set errors from the API
    * on a tcomb field. By default, also sets hasError to true if `error` is
    * truthy and false otherwise. You can disable this behavior by passing in
-   * the `autoHasError` option in the config object.
+   * the `overrideHasError` option in the config object.
    *
    * @param {string} error
    * @return {BaseBuilder}
    */
   setError(error, config = {}) {
-    const {
-      autoHasError = true,
-    } = config;
+    const { overrideHasError = false } = config;
     const builder = new this.constructor(this._state.mergeDeep({ options: { error } }));
-    return autoHasError ? builder.setHasError(!!error) : builder;
+    return overrideHasError ? builder : builder.setHasError(!!error);
   }
 
   /**

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -142,13 +142,19 @@ export default class BaseBuilder {
 
   /**
    * Set the error key in the options object. Used to set errors from the API
-   * on a tcomb field.
+   * on a tcomb field. By default, also sets hasError to true if `error` is
+   * truthy and false otherwise. You can disable this behavior by passing in
+   * the `autoHasError` option in the config object.
    *
    * @param {string} error
    * @return {BaseBuilder}
    */
-  setError(error) {
-    return new this.constructor(this._state.mergeDeep({ options: { error } }));
+  setError(error, config = {}) {
+    const {
+      autoHasError = true,
+    } = config;
+    const builder = new this.constructor(this._state.mergeDeep({ options: { error } }));
+    return autoHasError ? builder.setHasError(!!error) : builder;
   }
 
   /**

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -134,11 +134,18 @@ describe('BaseBuilder', () => {
       });
     });
 
+    describe('setHasError()', () => {
+      it('sets the hasError boolean in the options object', () => {
+        const builder = new BaseBuilder().setHasError(true);
+
+        expect(builder.getOptions().hasError).to.equal(true);
+      });
+    });
+
     describe('setError()', () => {
       it('sets an error key in the options object', () => {
         const error = 'errorStr';
-        const builder = new BaseBuilder()
-          .setError(error);
+        const builder = new BaseBuilder().setError(error);
 
         expect(builder.getOptions().error).to.equal(error);
       });

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -138,7 +138,7 @@ describe('BaseBuilder', () => {
       it('sets the hasError boolean in the options object', () => {
         const builder = new BaseBuilder().setHasError(true);
 
-        expect(builder.getOptions().hasError).to.equal(true);
+        expect(builder.getOptions().hasError).to.be.true;
       });
     });
 
@@ -148,6 +148,18 @@ describe('BaseBuilder', () => {
         const builder = new BaseBuilder().setError(error);
 
         expect(builder.getOptions().error).to.equal(error);
+      });
+
+      it('sets hasError to true in the options object by default', () => {
+        const builder = new BaseBuilder().setError('errorStr');
+
+        expect(builder.getOptions().hasError).to.be.true;
+      });
+
+      it('can set hasError to false in the options object', () => {
+        const builder = new BaseBuilder().setError('errorStr', { autoHasError: false });
+
+        expect(builder.getOptions().hasError).to.be.undefined;
       });
     });
 
@@ -225,7 +237,14 @@ describe('BaseBuilder', () => {
 
         expect(builder.getOptions()).to.deep.equal({
           disabled: true,
-          fields: { customField: { disabled: true, error: 'errorStr', label: 'foobar' } },
+          fields: {
+            customField: {
+              disabled: true,
+              error: 'errorStr',
+              hasError: true,
+              label: 'foobar',
+            },
+          },
           order: ['customField'],
         });
       });

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -156,7 +156,7 @@ describe('BaseBuilder', () => {
         expect(builder.getOptions().hasError).to.be.true;
       });
 
-      it('can set override setting hasError by default', () => {
+      it('overrides hasError setting by default', () => {
         const builder = new BaseBuilder().setError('errorStr', { overrideHasError: true });
 
         expect(builder.getOptions().hasError).to.be.undefined;

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -156,8 +156,8 @@ describe('BaseBuilder', () => {
         expect(builder.getOptions().hasError).to.be.true;
       });
 
-      it('can set hasError to false in the options object', () => {
-        const builder = new BaseBuilder().setError('errorStr', { autoHasError: false });
+      it('can set override setting hasError by default', () => {
+        const builder = new BaseBuilder().setError('errorStr', { overrideHasError: true });
 
         expect(builder.getOptions().hasError).to.be.undefined;
       });

--- a/src/examples/CharacterProfileBuilder.js
+++ b/src/examples/CharacterProfileBuilder.js
@@ -3,7 +3,7 @@ import { validators, widgets } from '../index';
 const name = widgets.TextBuilder.setLabel('Name');
 
 const dateOfBirth = widgets.TextBuilder
-  .setValidationErrorMessageFn(validators.date.birthdate)
+  .setValidation(validators.date.birthdate)
   .setLabel('Date of Birth');
 
 const occupation = widgets.TextBuilder
@@ -26,7 +26,7 @@ const crossValidation = validators.combine([
 ]);
 
 const foodGroup = widgets.CheckboxGroupBuilder
-  .setValidationErrorMessageFn(crossValidation)
+  .setValidation(crossValidation)
   .setField('bananaStand', bananaStand)
   .setField('chickenDance', chickenDance)
   .setField('hugeMistake', hugeMistake)

--- a/src/examples/TelevisionShowBuilder.js
+++ b/src/examples/TelevisionShowBuilder.js
@@ -3,7 +3,7 @@ import { validators, widgets } from '../index';
 const showName = widgets.TextBuilder.setLabel('Show Name');
 
 const firstEpisodeDate = widgets.TextBuilder
-  .setValidationErrorMessageFn(validators.date.birthdate)
+  .setValidation(validators.date.birthdate)
   .setLabel('Date of Birth');
 
 const genre = widgets.TextBuilder

--- a/src/primitives/CheckboxBuilder.js
+++ b/src/primitives/CheckboxBuilder.js
@@ -4,5 +4,5 @@ import BaseBuilder from '../BaseBuilder';
 import * as validators from '../validators';
 
 export default new BaseBuilder()
-  .setValidationErrorMessageFn(validators.checkbox.isBoolean)
+  .setValidation(validators.checkbox.isBoolean)
   .setTypeAndValidate(tcomb.Boolean, 'Checkbox');

--- a/src/primitives/NumberBuilder.js
+++ b/src/primitives/NumberBuilder.js
@@ -9,4 +9,4 @@ const validation = validators.combine([
 
 export default new BaseBuilder()
   .setTypeAndValidate(tcomb.Number, 'Number')
-  .setValidationErrorMessageFn(validation);
+  .setValidation(validation);

--- a/src/primitives/SelectBuilder.js
+++ b/src/primitives/SelectBuilder.js
@@ -21,4 +21,4 @@ class SelectBuilder extends BaseBuilder {
 }
 
 export default new SelectBuilder()
-  .setValidationErrorMessageFn(validators.shared.hasSelection);
+  .setValidation(validators.shared.hasSelection);

--- a/src/primitives/StructBuilder.js
+++ b/src/primitives/StructBuilder.js
@@ -17,4 +17,5 @@ class StructBuilder extends BaseBuilder {
 }
 
 export default new StructBuilder()
-  .setType((errorFn = () => {}, fields) => validation(tcomb.struct(fields), errorFn, 'Struct'));
+  .setValidation(() => null)
+  .setType((errorFn, fields) => validation(tcomb.struct(fields), errorFn, 'Struct'));

--- a/src/primitives/TextBuilder.js
+++ b/src/primitives/TextBuilder.js
@@ -10,4 +10,4 @@ const validation = validators.combine([
 
 export default new BaseBuilder()
   .setTypeAndValidate(tcomb.String, 'Text')
-  .setValidationErrorMessageFn(validation);
+  .setValidation(validation);

--- a/src/primitives/__tests__/CheckboxBuilder.spec.js
+++ b/src/primitives/__tests__/CheckboxBuilder.spec.js
@@ -12,17 +12,15 @@ describe('CheckboxBuilder', () => {
 
   it('throws an error message when passed a null value', () => {
     const checkbox = a.getType();
-    const options = a.getOptions();
 
     expect(() => checkbox(null)).to.throw();
-    expect(options.error(null)).to.equal('Value must be a boolean');
+    expect(checkbox.getValidationErrorMessage(null)).to.equal('Value must be a boolean');
   });
 
   it('produces an error message if the value is not a boolean', () => {
     const checkbox = a.getType();
-    const options = a.getOptions();
 
     expect(() => checkbox('TRUE')).to.throw();
-    expect(options.error('TRUE')).to.equal('Value must be a boolean');
+    expect(checkbox.getValidationErrorMessage('TRUE')).to.equal('Value must be a boolean');
   });
 });

--- a/src/primitives/__tests__/NumberBuilder.spec.js
+++ b/src/primitives/__tests__/NumberBuilder.spec.js
@@ -5,14 +5,11 @@ import NumberBuilder from '../NumberBuilder';
 describe('NumberBuilder', () => {
   it('produces a NumberType that validates correctly', () => {
     const NumberType = NumberBuilder.getType();
+
     expect(validate('banana', NumberType).isValid()).to.be.false;
     expect(validate(42, NumberType).isValid()).to.be.true;
-  });
-
-  it('produces a NumberType options object that is formed correctly', () => {
-    const options = NumberBuilder.getOptions();
-    expect(options.error('banana')).to.equal('Please provide a number');
-    expect(options.error(42)).to.equal(null);
-    expect(options.error(null)).to.equal('Please provide a number');
+    expect(NumberType.getValidationErrorMessage('banana')).to.equal('Please provide a number');
+    expect(NumberType.getValidationErrorMessage(42)).to.equal(null);
+    expect(NumberType.getValidationErrorMessage(null)).to.equal('Please provide a number');
   });
 });

--- a/src/primitives/__tests__/SelectBuilder.spec.js
+++ b/src/primitives/__tests__/SelectBuilder.spec.js
@@ -8,23 +8,23 @@ const trueFalseSelect = SelectBuilder
 
 describe('SelectBuilder', () => {
   it('should validate input properly', () => {
-    const builder = testSelect.getType();
+    const SelectType = testSelect.getType();
     const selection = 'dog';
 
-    expect(builder(selection)).to.equal('dog');
+    expect(SelectType(selection)).to.equal('dog');
   });
 
   it('should produce an error message for invalid input', () => {
-    const builder = testSelect.getType();
+    const SelectType = testSelect.getType();
     const selection = 'bird';
 
-    expect(() => builder(selection)).to.throw();
+    expect(() => SelectType(selection)).to.throw();
   });
 
   it('should return an error when selection is empty', () => {
-    const options = testSelect.getOptions();
+    const SelectType = testSelect.getType();
 
-    expect(options.error(null)).to.equal('Required');
+    expect(SelectType.getValidationErrorMessage(null)).to.equal('Required');
   });
 
   // Test a regression where we were checking for !value in the RadioType

--- a/src/primitives/__tests__/StructBuilder.spec.js
+++ b/src/primitives/__tests__/StructBuilder.spec.js
@@ -2,11 +2,12 @@ import TextBuilder from '../TextBuilder';
 import StructBuilder from '../StructBuilder';
 
 const exampleStruct = StructBuilder
+  .setValidation(() => null)
   .setField('first', TextBuilder.setLabel('first'))
   .setField('second', TextBuilder.setLabel('second'));
 
 describe('StructBuilder', () => {
-  it('produces a StructType object that validates correctly', () => {
+  it('produces a valid struct type', () => {
     const StructType = exampleStruct.getType();
     const json = { first: 'abc', second: '123' };
 
@@ -14,7 +15,7 @@ describe('StructBuilder', () => {
     expect(StructType(json).second).to.equal('123');
   });
 
-  it('produces a StructType options object that validates correctly', () => {
+  it('produces a valid struct options object', () => {
     const actual = exampleStruct.getOptions();
 
     const expected = {

--- a/src/primitives/__tests__/StructBuilder.spec.js
+++ b/src/primitives/__tests__/StructBuilder.spec.js
@@ -2,7 +2,6 @@ import TextBuilder from '../TextBuilder';
 import StructBuilder from '../StructBuilder';
 
 const exampleStruct = StructBuilder
-  .setValidation(() => null)
   .setField('first', TextBuilder.setLabel('first'))
   .setField('second', TextBuilder.setLabel('second'));
 

--- a/src/primitives/__tests__/TextBuilder.spec.js
+++ b/src/primitives/__tests__/TextBuilder.spec.js
@@ -3,18 +3,15 @@ import { validate } from 'tcomb-validation';
 import TextBuilder from '../TextBuilder';
 
 describe('TextBuilder', () => {
-  it('produces a TextType object that validates correctly', () => {
+  it('produces a valid type', () => {
     const TextType = TextBuilder.getType();
+
     expect(validate('banana', TextType).isValid()).to.be.true;
     expect(validate('', TextType).isValid()).to.be.false;
     expect(validate(42, TextType).isValid()).to.be.false;
     expect(validate(null, TextType).isValid()).to.be.false;
     expect(validate(undefined, TextType).isValid()).to.be.false;
-  });
-
-  it('produces a TextType options object that is formed correctly', () => {
-    const options = TextBuilder.getOptions();
-    expect(options.error('banana')).to.equal(null);
-    expect(options.error(null)).to.equal('Required');
+    expect(TextType.getValidationErrorMessage('banana')).to.equal(null);
+    expect(TextType.getValidationErrorMessage(null)).to.equal('Required');
   });
 });

--- a/src/primitives/__tests__/UnionBuilder.spec.js
+++ b/src/primitives/__tests__/UnionBuilder.spec.js
@@ -7,8 +7,10 @@ describe('UnionBuilder', () => {
   describe('setUnion and setDispatch', () => {
     it('should create a valid union type', () => {
       const international = StructBuilder
+        .setValidation(() => null)
         .setField('country', TextBuilder);
       const usa = StructBuilder
+        .setValidation(() => null)
         .setField('country', TextBuilder)
         .setField('state', TextBuilder);
       const countriesBuilder = UnionBuilder

--- a/src/primitives/__tests__/UnionBuilder.spec.js
+++ b/src/primitives/__tests__/UnionBuilder.spec.js
@@ -7,10 +7,8 @@ describe('UnionBuilder', () => {
   describe('setUnion and setDispatch', () => {
     it('should create a valid union type', () => {
       const international = StructBuilder
-        .setValidation(() => null)
         .setField('country', TextBuilder);
       const usa = StructBuilder
-        .setValidation(() => null)
         .setField('country', TextBuilder)
         .setField('state', TextBuilder);
       const countriesBuilder = UnionBuilder

--- a/src/widgets/DropDownBuilder.js
+++ b/src/widgets/DropDownBuilder.js
@@ -2,5 +2,5 @@ import SelectBuilder from '../primitives/SelectBuilder';
 import * as validators from '../validators';
 
 export default SelectBuilder
-  .setValidationErrorMessageFn(validators.shared.hasSelection)
+  .setValidation(validators.shared.hasSelection)
   .setLazyTemplateFactory(provider => provider.getDropDown());

--- a/src/widgets/RadioBuilder.js
+++ b/src/widgets/RadioBuilder.js
@@ -17,5 +17,5 @@ class RadioBuilder extends SelectBuilder.constructor {
 }
 
 export default new RadioBuilder()
-  .setValidationErrorMessageFn(validators.shared.hasSelection)
+  .setValidation(validators.shared.hasSelection)
   .setLazyTemplateFactory(provider => provider.getRadio());

--- a/src/widgets/StaticPageBuilder.js
+++ b/src/widgets/StaticPageBuilder.js
@@ -3,7 +3,7 @@ import tcomb from 'tcomb-validation';
 import BaseBuilder from '../BaseBuilder';
 
 export default new BaseBuilder()
-  .setValidationErrorMessageFn(() => null)
+  .setValidation(() => null)
   .setTypeAndValidate(tcomb.Any, 'Static Text')
   .setLazyTemplateFactory(provider => provider.getStaticPage());
 

--- a/src/widgets/__tests__/CheckboxGroupBuilder.spec.js
+++ b/src/widgets/__tests__/CheckboxGroupBuilder.spec.js
@@ -6,50 +6,50 @@ const a = CheckboxBuilder.setLabel('a');
 const b = CheckboxBuilder.setLabel('b');
 const c = CheckboxBuilder.setLabel('c');
 
-const exampleCheckboxes = CheckboxGroupBuilder
-  .setValidationErrorMessageFn(validators.checkbox.minMax({ min: 0, max: 2 }))
+const checkboxGroupBuilder = CheckboxGroupBuilder
+  .setValidation(validators.checkbox.minMax({ min: 0, max: 2 }))
   .setField('a', a)
   .setField('b', b)
   .setField('c', c);
 
 describe('CheckboxGroupBuilder', () => {
   it('produces a tcomb Struct that validates correctly', () => {
-    const checkboxGroupType = exampleCheckboxes
-      .setValidationErrorMessageFn(validators.checkbox.minMax({ min: 0, max: 3 }))
+    const CheckboxGroupType = checkboxGroupBuilder
+      .setValidation(validators.checkbox.minMax({ min: 0, max: 3 }))
       .getType();
-    const checkbox = CheckboxBuilder.getType();
+    const CheckboxType = CheckboxBuilder.getType();
     const selections = {
-      a: checkbox(false),
-      b: checkbox(true),
-      c: checkbox(false),
+      a: CheckboxType(false),
+      b: CheckboxType(true),
+      c: CheckboxType(false),
     };
 
-    expect(checkboxGroupType(selections)).to.deep.equal({ a: false, b: true, c: false });
+    expect(CheckboxGroupType(selections)).to.deep.equal({ a: false, b: true, c: false });
   });
 
   it('produces an error message if number of selected values is less than the min', () => {
-    const Checkboxes = exampleCheckboxes
-      .setValidationErrorMessageFn(validators.checkbox.minMax({ min: 1, max: 1 }));
+    const builder = checkboxGroupBuilder
+      .setValidation(validators.checkbox.minMax({ min: 1, max: 1 }));
 
-    const CheckboxGroupType = Checkboxes.getType();
-    const options = Checkboxes._disableTemplates().getOptions();
+    const CheckboxGroupType = builder.getType();
 
     const selections = { a: false, b: false };
 
     expect(() => CheckboxGroupType(selections)).to.throw();
-    expect(options.error(selections)).to.equal('Please select at least 1 item.');
+    const errorStr = 'Please select at least 1 item.';
+    expect(CheckboxGroupType.getValidationErrorMessage(selections)).to.equal(errorStr);
   });
 
   it('produces an error message if number of selected values more than the max', () => {
-    const Checkboxes = exampleCheckboxes
-      .setValidationErrorMessageFn(validators.checkbox.minMax({ min: 1, max: 1 }));
+    const builder = checkboxGroupBuilder
+      .setValidation(validators.checkbox.minMax({ min: 1, max: 1 }));
 
-    const CheckboxGroupType = Checkboxes.getType();
-    const options = Checkboxes._disableTemplates().getOptions();
+    const CheckboxGroupType = builder.getType();
 
     const selections = { a: true, b: true };
 
     expect(() => CheckboxGroupType(selections)).to.throw();
-    expect(options.error(selections)).to.equal('Please select at most 1 item.');
+    const errorStr = 'Please select at most 1 item.';
+    expect(CheckboxGroupType.getValidationErrorMessage(selections)).to.equal(errorStr);
   });
 });


### PR DESCRIPTION
- Rename `setValidationErrorMessageFn` to `setValidation`
  - `setValidation` sets `getValidationErrorMessage` on the realized tcomb type
- `setError` sets the `error` key in the options blob
- Fix all tests
- Update/add documentation

TODO:
- [x] Bump to 4.0.0