### PR TITLE
Builder equality check

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ function validation(value) {
 }
 
 const TextBuilder = new BaseBuilder()
-  .setTypeAndValidate(tcomb.String, 'Text')
-  .setValidation(validation, 'LengthValidation');
+  .setTypeAndValidate('Text', tcomb.String)
+  .setValidation('LengthValidation', validation);
 
 const firstName = TextBuilder.setLabel('First Name');
 
@@ -130,7 +130,7 @@ import { primitives, validators, widgets } from 'tcomb-builder';
 const name = widgets.TextBuilder.setLabel('Name');
 
 const dateOfBirth = widgets.TextBuilder
-  .setValidation(validators.date.birthdate, 'BirthdateValidation')
+  .setValidation('BirthdateValidation', validators.date.birthdate)
   .setLabel('Date of Birth');
 
 const occupation = widgets.TextBuilder
@@ -153,7 +153,7 @@ const crossValidation = validators.combine([
 ]);
 
 const foodGroup = widgets.CheckboxGroupBuilder
-  .setValidation(crossValidation, 'SelectOneOrTwo')
+  .setValidation('SelectOneOrTwo', crossValidation)
   .setField('bananaStand', bananaStand)
   .setField('chickenDance', chickenDance)
   .setField('hugeMistake', hugeMistake)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ function validation(value) {
 
 const TextBuilder = new BaseBuilder()
   .setTypeAndValidate(tcomb.String, 'Text')
-  .setValidation(validation);
+  .setValidation(validation, 'LengthValidation');
 
 const firstName = TextBuilder.setLabel('First Name');
 
@@ -130,7 +130,7 @@ import { primitives, validators, widgets } from 'tcomb-builder';
 const name = widgets.TextBuilder.setLabel('Name');
 
 const dateOfBirth = widgets.TextBuilder
-  .setValidation(validators.date.birthdate)
+  .setValidation(validators.date.birthdate, 'BirthdateValidation')
   .setLabel('Date of Birth');
 
 const occupation = widgets.TextBuilder
@@ -153,7 +153,7 @@ const crossValidation = validators.combine([
 ]);
 
 const foodGroup = widgets.CheckboxGroupBuilder
-  .setValidation(crossValidation)
+  .setValidation(crossValidation, 'CrossValidation')
   .setField('bananaStand', bananaStand)
   .setField('chickenDance', chickenDance)
   .setField('hugeMistake', hugeMistake)

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ const crossValidation = validators.combine([
 ]);
 
 const foodGroup = widgets.CheckboxGroupBuilder
-  .setValidation(crossValidation, 'CrossValidation')
+  .setValidation(crossValidation, 'SelectOneOrTwo')
   .setField('bananaStand', bananaStand)
   .setField('chickenDance', chickenDance)
   .setField('hugeMistake', hugeMistake)

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -449,6 +449,16 @@ Disable template realization for this builder and any fields that it contains.
 This method is intended to be used only in unit tests for surveys where
 template callbacks are set, but no template provider is made available.
 
+## `isEqual()`
+
+### Summary
+
+Test for builder value equality.
+
+### Parameters
+
+**other**: `BaseBuilder`
+
 ## `getType()`
 
 ### Summary

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -58,25 +58,27 @@ display value in select and radio groups.
 
 ### Summary
 
-Set what properties should be automatically generated for you.
-Options are: 'labels', 'placeholders', 'none'.
+Set what properties should be automatically generated for you.  Options are:
+'labels', 'placeholders', 'none'.
 
 ### Parameters
 
 **text**: `string`
 
-## `setTransformer(transformer)`
+## `setTransformer(transformer, name)`
 
 ### Summary
 
 Set the transformer object in the options object for this type. The transformer
 object has two keys: `parse` and `format`. `parse` is a function describing how
 values will be transformed going into the type; `format` describes how they come
-out.
+out. The `name` parameter is used when checking for builder equality.
 
 ### Parameters
 
 **transformer**: `object` transformer
+
+**name**: `string`
 
 ## `setHelp(help)`
 
@@ -110,21 +112,24 @@ template factory using this method will supersede the lazy one.
 
 **factory**: `TemplateFactory`
 
-## `setLazyTemplateFactory(callback)`
+## `setLazyTemplateFactory(callback, name)`
 
 ### Summary
 
 Set a template provider for this field in its options object. Because the
 provider is accessed at builder evaluation time, it is necessary to set the
 factory by passing a callback function to the `setLazyTemplateFactory` method.
+The `name` parameter is used when checking for builder equality.
 
 ### Example
 
-`.setLazyTemplateFactory(provider => provider.getTextField())`
+`.setLazyTemplateFactory(provider => provider.getTextField(), 'TextField')`
 
 ### Parameters
 
 **factory**: `LazyTemplateInterface => TemplateFactory`
+
+**name**: `string`
 
 ## `setError(error)`
 
@@ -176,14 +181,14 @@ const field = new BaseBuilder()
 
 **hasError**: `boolean`
 
-## `setValidation(getValidationErrorMessage)`
+## `setValidation(getValidationErrorMessage, name)`
 
 ### Summary
 
 Set a validation function for this field as a static function on its type. The
 validation function must conform to the same spec as that in `tcomb-validation`
 where it returns `null` if there is no error, and a `string` if an error
-occurred.
+occurred. The `name` parameter is used when checking for builder equality.
 
 ### Example
 
@@ -193,20 +198,23 @@ function getValidationErrorMessage(value) {
 }
 
 const field = new BaseBuilder()
-    .setValidation(getValidationErrorMessage);
+    .setValidation(getValidationErrorMessage, 'BooleanValidation');
 ```
 
 ### Parameters
 
 **getValidationErrorMessage**: `(value, path, context) => ?(string | ReactElement)`
 
-## `addValidation(getValidationErrorMessage)`
+**name**: `string`
+
+## `addValidation(getValidationErrorMessage, name)`
 
 ### Summary
 
 Adds a validation function to the existing function in the options object for
 this type. If there is no existing validation function, then it is equivalent
-to `setValidation`.
+to `setValidation`. The `name` parameter is used when checking for builder
+equality.
 
 ### Example
 
@@ -220,13 +228,15 @@ function truthyValidation(value) {
 }
 
 const field = new BaseBuilder()
-    .setValidation(booleanValidation)
-    .addValidation(truthyValidation);
+    .setValidation(booleanValidation, 'BooleanValidation')
+    .addValidation(truthyValidation, 'TruthyValidation');
 ```
 
 ### Parameters
 
 **getValidationErrorMessage**: `(value, path, context) => ?(string | ReactElement)`
+
+**name**: `string`
 
 ## `setField(key, fieldBuilder)`
 
@@ -279,21 +289,21 @@ const noBuilder = new BaseBuilder()
 export default RadioBuilder
     .addSelectOption(yesBuilder)
     .addSelectOption(noBuilder)
-    .setTypeAndValidate(tcomb.enums.of([true, false]));
+    .setTypeAndValidate(tcomb.enums.of([true, false]), 'YesNoBuilder');
 ```
 
 ### Parameters
 
 **selectBuilder**: `BaseBuilder`
 
-## `setType(typeCombinator)`
+## `setType(typeCombinator, name)`
 
 ### Summary
 
 Set the tcomb type of this builder. The type must be passed in as a callback
 function in order to allow for arbitrary ordering of builder commands. The
 validation function and fields are provided to you when you are creating the
-type.
+type. The `name` parameter is used when checking for builder equality.
 
 ### Example
 
@@ -302,6 +312,8 @@ See the [`StructBuilder`](../src/primitives/StructBuilder.js)
 ### Parameters
 
 **typeCombinator**: `(errorFn: (value: string) => boolean, subTypes: Object) => TcombType`
+
+**name**: `string`
 
 ## `setTypeAndValidate(type, name)`
 
@@ -316,17 +328,20 @@ defined by the type.
 
 **name**: `string`
 
-## `setLazyTemplateProvider(provider)`
+## `setLazyTemplateProvider(provider, name)`
 
 ### Summary
 
 Sets a template provider instance. Set the provider only on the top level
-type, and it will be used to recursively generate templates for all
-sub-field options objects.
+type, and it will be used to recursively generate templates for all sub-field
+options objects. The `name` parameter is used when checking for builder
+equality.
 
 ### Parameters
 
 **provider**: `LazyTemplateInterface`
+
+**name**: `string`
 
 ## `makeOptional(isOptional = true)`
 
@@ -412,16 +427,19 @@ for telling the template how much padding to put around the component.
 
 **rhythm**: `string`
 
-## `setSort(sortComparator)`
+## `setSort(sortComparator, name)`
 
 ### Summary
 
 Set the sort function in the config object for this type. This function will be
-used to tell the template how to sort the values in the enum.
+used to tell the template how to sort the values in the enum. The `name`
+parameter is used when checking for builder equality.
 
 ### Parameters
 
 **order**: `(a, b) => number`
+
+**name**: `string`
 
 ## `_disableTemplates()`
 

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -65,7 +65,7 @@ Set what properties should be automatically generated for you.  Options are:
 
 **text**: `string`
 
-## `setTransformer(transformer, name)`
+## `setTransformer(name, transformer)`
 
 ### Summary
 
@@ -76,9 +76,9 @@ out. The `name` parameter is used when checking for builder equality.
 
 ### Parameters
 
-**transformer**: `object` transformer
-
 **name**: `string`
+
+**transformer**: `object` transformer
 
 ## `setHelp(help)`
 
@@ -112,7 +112,7 @@ template factory using this method will supersede the lazy one.
 
 **factory**: `TemplateFactory`
 
-## `setLazyTemplateFactory(callback, name)`
+## `setLazyTemplateFactory(name, callback)`
 
 ### Summary
 
@@ -123,13 +123,13 @@ The `name` parameter is used when checking for builder equality.
 
 ### Example
 
-`.setLazyTemplateFactory(provider => provider.getTextField(), 'TextField')`
+`.setLazyTemplateFactory('TextField', provider => provider.getTextField())`
 
 ### Parameters
 
-**factory**: `LazyTemplateInterface => TemplateFactory`
-
 **name**: `string`
+
+**factory**: `LazyTemplateInterface => TemplateFactory`
 
 ## `setError(error)`
 
@@ -181,7 +181,7 @@ const field = new BaseBuilder()
 
 **hasError**: `boolean`
 
-## `setValidation(getValidationErrorMessage, name)`
+## `setValidation(name, getValidationErrorMessage)`
 
 ### Summary
 
@@ -198,16 +198,16 @@ function getValidationErrorMessage(value) {
 }
 
 const field = new BaseBuilder()
-    .setValidation(getValidationErrorMessage, 'BooleanValidation');
+    .setValidation('BooleanValidation', getValidationErrorMessage);
 ```
 
 ### Parameters
 
-**getValidationErrorMessage**: `(value, path, context) => ?(string | ReactElement)`
-
 **name**: `string`
 
-## `addValidation(getValidationErrorMessage, name)`
+**getValidationErrorMessage**: `(value, path, context) => ?(string | ReactElement)`
+
+## `addValidation(name, getValidationErrorMessage)`
 
 ### Summary
 
@@ -228,15 +228,15 @@ function truthyValidation(value) {
 }
 
 const field = new BaseBuilder()
-    .setValidation(booleanValidation, 'BooleanValidation')
-    .addValidation(truthyValidation, 'TruthyValidation');
+    .setValidation('BooleanValidation', booleanValidation)
+    .addValidation('TruthyValidation', truthyValidation);
 ```
 
 ### Parameters
 
-**getValidationErrorMessage**: `(value, path, context) => ?(string | ReactElement)`
-
 **name**: `string`
+
+**getValidationErrorMessage**: `(value, path, context) => ?(string | ReactElement)`
 
 ## `setField(key, fieldBuilder)`
 
@@ -289,14 +289,14 @@ const noBuilder = new BaseBuilder()
 export default RadioBuilder
     .addSelectOption(yesBuilder)
     .addSelectOption(noBuilder)
-    .setTypeAndValidate(tcomb.enums.of([true, false]), 'YesNoBuilder');
+    .setTypeAndValidate('YesNoBuilder', tcomb.enums.of([true, false]));
 ```
 
 ### Parameters
 
 **selectBuilder**: `BaseBuilder`
 
-## `setType(typeCombinator, name)`
+## `setType(name, typeCombinator)`
 
 ### Summary
 
@@ -311,11 +311,11 @@ See the [`StructBuilder`](../src/primitives/StructBuilder.js)
 
 ### Parameters
 
-**typeCombinator**: `(errorFn: (value: string) => boolean, subTypes: Object) => TcombType`
-
 **name**: `string`
 
-## `setTypeAndValidate(type, name)`
+**typeCombinator**: `(errorFn: (value: string) => boolean, subTypes: Object) => TcombType`
+
+## `setTypeAndValidate(name, type)`
 
 ### Summary
 
@@ -324,9 +324,9 @@ defined by the type.
 
 ### Parameters
 
-**type**: `TcombType`
-
 **name**: `string`
+
+**type**: `TcombType`
 
 ## `setLazyTemplateProvider(provider)`
 
@@ -424,7 +424,7 @@ for telling the template how much padding to put around the component.
 
 **rhythm**: `string`
 
-## `setSort(sortComparator, name)`
+## `setSort(name, sortComparator)`
 
 ### Summary
 
@@ -434,9 +434,9 @@ parameter is used when checking for builder equality.
 
 ### Parameters
 
-**order**: `(a, b) => number`
-
 **name**: `string`
+
+**order**: `(a, b) => number`
 
 ## `_disableTemplates()`
 

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -328,20 +328,17 @@ defined by the type.
 
 **name**: `string`
 
-## `setLazyTemplateProvider(provider, name)`
+## `setLazyTemplateProvider(provider)`
 
 ### Summary
 
 Sets a template provider instance. Set the provider only on the top level
 type, and it will be used to recursively generate templates for all sub-field
-options objects. The `name` parameter is used when checking for builder
-equality.
+options objects.
 
 ### Parameters
 
 **provider**: `LazyTemplateInterface`
-
-**name**: `string`
 
 ## `makeOptional(isOptional = true)`
 

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -450,7 +450,17 @@ template callbacks are set, but no template provider is made available.
 
 ### Summary
 
-Test for builder value equality.
+Test for builder value equality. Internally, everything set on the builder is
+compared. Order matters for some methods, for example `setField` and
+`setValidation`, since their order also changes the resulting options and type
+objects.
+
+Methods that take functions as parameters use the key that is also set in that
+function as the point of comparison. If `.setValidation('foo', () => 'foo')`
+is called on one builder and `.setValidation('foo', () => 'bar')` on an
+equivalent builder, the builders will be considered equivalent, despite the
+functions being different. Key names are used instead of function references
+when checking equality because references will change when the page re-renders.
 
 ### Parameters
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -16,8 +16,8 @@ Let's look at the type signatures of these methods:
 ### `setLazyTemplateFactory` and `setLazyTemplateProvider`
 
 ```js
-setLazyTemplateFactory : (LazyTemplateInterface -> tcomb.form.Component, string) => BaseBuilder
-builder.setLazyTemplateFactory(provider -> provider.getTextField(), 'TextField')
+setLazyTemplateFactory : (string, LazyTemplateInterface -> tcomb.form.Component) => BaseBuilder
+builder.setLazyTemplateFactory('TextField', provider -> provider.getTextField())
 
 setLazyTemplateProvider : LazyTemplateInterface => BaseBuilder
 builder.setLazyTemplateProvider(provider)
@@ -36,14 +36,14 @@ available to every text field contained therein.
 ### `setType`
 
 ```js
-setType : (getValidationErrorMessage: any => string, subTypes: Object), name: string => TcombType
-builder.setType(getValidationErrorMessage => tcomb.refinement(
+setType : name: string, (getValidationErrorMessage: any => string, subTypes: Object) => TcombType
+builder.setType('String', getValidationErrorMessage => tcomb.refinement(
   tcomb.String,
   x => !tcomb.String.is(getValidationErrorMessage(x),
   'String',
-), 'String')
+))
 // or
-builder.setType((errorFn, fields) => tcomb.struct(fields), 'FooStruct');
+builder.setType('FooStruct', (errorFn, fields) => tcomb.struct(fields));
 ```
 
 Here we see that `setType` takes a function which returns a tcomb type. That

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -16,8 +16,8 @@ Let's look at the type signatures of these methods:
 ### `setLazyTemplateFactory` and `setLazyTemplateProvider`
 
 ```js
-setLazyTemplateFactory : (LazyTemplateInterface -> tcomb.form.Component) => BaseBuilder
-builder.setLazyTemplateFactory(provider -> provider.getTextField())
+setLazyTemplateFactory : (LazyTemplateInterface -> tcomb.form.Component, string) => BaseBuilder
+builder.setLazyTemplateFactory(provider -> provider.getTextField(), 'TextField')
 
 setLazyTemplateProvider : LazyTemplateInterface => BaseBuilder
 builder.setLazyTemplateProvider(provider)
@@ -36,10 +36,14 @@ available to every text field contained therein.
 ### `setType`
 
 ```js
-setType : (errorFn: (value: string) => boolean, subTypes: Object) => TcombType
-builder.setType(errorFn => validation(tcomb.String, errorFn, 'String'));
+setType : (getValidationErrorMessage: any => string, subTypes: Object), name: string => TcombType
+builder.setType(getValidationErrorMessage => tcomb.refinement(
+  tcomb.String,
+  x => !tcomb.String.is(getValidationErrorMessage(x),
+  'String',
+), 'String')
 // or
-builder.setType((errorFn, fields) => tcomb.struct(fields));
+builder.setType((errorFn, fields) => tcomb.struct(fields), 'FooStruct');
 ```
 
 Here we see that `setType` takes a function which returns a tcomb type. That

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -19,7 +19,7 @@ import * as validators from './path/to/validators';
 import TextBuilder from './path/to/TextBuilder';
 
 const zipCode = TextBuilder
-  .setValidation(validators.text.length(5), 'LengthValidation');
+  .setValidation('LengthValidation', validators.text.length(5));
 ```
 
 A common need is to perform several different validations on a single field.
@@ -50,7 +50,7 @@ const crossValidation = validators.combine([
 ]);
 
 const foodGroup = widgets.CheckboxGroupBuilder
-    .setValidation(crossValidation, 'CrossValidation')
+    .setValidation('CrossValidation', crossValidation)
     .setField('bananaStand', bananaStand)
     .setField('chickenDance', chickenDance)
     .setField('hugeMistake', hugeMistake)

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -18,7 +18,8 @@ When you import the `validators` object, you can use its string length validator
 import * as validators from './path/to/validators';
 import TextBuilder from './path/to/TextBuilder';
 
-const zipCode = TextBuilder.setValidation(validators.text.length(5));
+const zipCode = TextBuilder
+  .setValidation(validators.text.length(5), 'LengthValidation');
 ```
 
 A common need is to perform several different validations on a single field.
@@ -49,7 +50,7 @@ const crossValidation = validators.combine([
 ]);
 
 const foodGroup = widgets.CheckboxGroupBuilder
-    .setValidation(crossValidation)
+    .setValidation(crossValidation, 'CrossValidation')
     .setField('bananaStand', bananaStand)
     .setField('chickenDance', chickenDance)
     .setField('hugeMistake', hugeMistake)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "lint": "eslint --cache '**/*.js'",
     "prepublish": "babel -d dist src",
-    "test": "NODE_ENV=test mocha --opts mocha.opts 'src/**/__tests__/**/*.js'",
+    "test": "NODE_ENV=test mocha --opts mocha.opts 'src/**/__tests__/**/*.js' -g 'for each sub-field'",
     "test:instrument": "NODE_ENV=test nyc --all --cache npm test",
     "test:junit": "NODE_ENV=test nyc --all --cache --reporter=cobertura --report-dir=./reports/coverage mocha --opts mocha.opts --reporter mocha-junit-reporter --reporter-options mochaFile=./reports/junit-report.xml 'src/**/__tests__/**/*.js'",
     "watch:test": "nodemon -w ./src -e js -x 'npm test'"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcomb-builder",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "A declarative syntax for building Tcomb type and options objects",
   "main": "dist/index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "lint": "eslint --cache '**/*.js'",
     "prepublish": "babel -d dist src",
-    "test": "NODE_ENV=test mocha --opts mocha.opts 'src/**/__tests__/**/*.js' -g 'for each sub-field'",
+    "test": "NODE_ENV=test mocha --opts mocha.opts 'src/**/__tests__/**/*.js'",
     "test:instrument": "NODE_ENV=test nyc --all --cache npm test",
     "test:junit": "NODE_ENV=test nyc --all --cache --reporter=cobertura --report-dir=./reports/coverage mocha --opts mocha.opts --reporter mocha-junit-reporter --reporter-options mochaFile=./reports/junit-report.xml 'src/**/__tests__/**/*.js'",
     "watch:test": "nodemon -w ./src -e js -x 'npm test'"

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -426,6 +426,10 @@ export default class BaseBuilder {
       return false;
     }
 
+    if (otherBuilder === this) {
+      return true;
+    }
+
     const equalFields = this._state.get('_fieldBuilders').entrySeq().every(entry => {
       const key = entry[0];
       const field = entry[1];

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -164,15 +164,18 @@ export default class BaseBuilder {
    * instance of `LazyTemplateInterface` can be made available to all
    * sub-fields recursively.
    *
-   * @param {callback} callback - Function which takes an instance of
-   * `LazyTemplateInterface` and returns a template provider class
    * @param {string} name - Identifier for the lazy template factory; used
    * internally to check builder equality
+   * @param {callback} callback - Function which takes an instance of
+   * `LazyTemplateInterface` and returns a template provider class
    * @return {BaseBuilder}
    */
-  setLazyTemplateFactory(callback, name) {
+  setLazyTemplateFactory(name, callback) {
     return new this.constructor(this._state
-      .mergeIn(['builderFunctions', '_templateProviderCallback'], { name, value: callback }));
+      .mergeIn(['builderFunctions', '_templateProviderCallback'], {
+        name,
+        value: callback,
+      }));
   }
 
   /**
@@ -206,12 +209,12 @@ export default class BaseBuilder {
    * Set a validation function that will be set on the tcomb type when it is
    * realized. This method will override previously set functions.
    *
-   * @param {function} getValidationErrorMessage
    * @param {string} name - Identifier for the validation function; used
    * internally to check builder equality
+   * @param {function} getValidationErrorMessage
    * @return {BaseBuilder}
    */
-  setValidation(getValidationErrorMessage, name) {
+  setValidation(name, getValidationErrorMessage) {
     return new this.constructor(this._state
       .mergeIn(['builderFunctions', '_getValidationErrorMessage'], {
         name,
@@ -222,27 +225,33 @@ export default class BaseBuilder {
   /**
    * Set the transformer function in the options object for this type.
    *
-   * @param {transformer} transformer
    * @param {string} name - Identifier for the transformer function; used
    * internally to check builder equality
+   * @param {transformer} transformer
    * @return {BaseBuilder}
    */
-  setTransformer(transformer, name) {
+  setTransformer(name, transformer) {
     return new this.constructor(this._state
-      .mergeIn(['optionsFunctions', 'transformer'], { name, value: transformer }));
+      .mergeIn(['optionsFunctions', 'transformer'], {
+        name,
+        value: transformer,
+      }));
   }
 
   /**
    * Set the sort comparator in the config object for this type.
    *
-   * @param {(Any, Any) => Integer} sortComparator
    * @param {string} name - Identifier for the sort function; used internally
    * to check builder equality
+   * @param {(Any, Any) => Integer} sortComparator
    * @return {BaseBuilder}
    */
-  setSort(sortComparator, name) {
+  setSort(name, sortComparator) {
     return new this.constructor(this._state
-      .mergeIn(['configFunctions', 'sortComparator'], { name, value: sortComparator }));
+      .mergeIn(['configFunctions', 'sortComparator'], {
+        name,
+        value: sortComparator,
+      }));
   }
 
   /**
@@ -250,15 +259,15 @@ export default class BaseBuilder {
    * If a function is not already set, then it is equivalent to
    * `setValidation`.
    *
-   * @param {function} getValidationErrorMessage
    * @param {string} name - Identifier for the validation function; used
    * internally to check builder equality
+   * @param {function} getValidationErrorMessage
    * @return {BaseBuilder}
    */
-  addValidation(getValidationErrorMessage, name) {
+  addValidation(name, getValidationErrorMessage) {
     const existingFn = this._getBuilderFunction('_getValidationErrorMessage');
     if (!existingFn) {
-      return this.setValidation(getValidationErrorMessage, name);
+      return this.setValidation(name, getValidationErrorMessage);
     }
 
     return new this.constructor(this._state
@@ -330,28 +339,30 @@ export default class BaseBuilder {
    * ordering of builder commands, wait to realize the type until the `getType`
    * method is called.
    *
-   * @param {typeCombinatorCallback} typeCombinator - set a lazily executed
-   * type on the internal state
    * @param {string} name - Identifier for the type function; used internally
    * to check builder equality
+   * @param {typeCombinatorCallback} typeCombinator - set a lazily executed
+   * type on the internal state
    * @return {BaseBuilder}
    */
-  setType(typeCombinator, name) {
+  setType(name, typeCombinator) {
     return new this.constructor(this._state
-      .mergeIn(['builderFunctions', '_type'],
-        { name, value: (errorFn, subTypes) => typeCombinator(errorFn, subTypes) }));
+      .mergeIn(['builderFunctions', '_type'], {
+        name,
+        value: (errorFn, subTypes) => typeCombinator(errorFn, subTypes),
+      }));
   }
 
   /**
    * Convenience function for setting the type and using the built-in
    * validation defined by the type.
-   * @param {type} type
    * @param {string} name - Identifier for the type function; used internally
    * to check builder equality
+   * @param {type} type
    * @return {BaseBuilder}
    */
-  setTypeAndValidate(type, name) {
-    return this.setType(getValidationErrorMessage => {
+  setTypeAndValidate(name, type) {
+    return this.setType(name, getValidationErrorMessage => {
       if (!getValidationErrorMessage) {
         throw new Error('You called setTypeAndValidate without setting a '
         + 'validationErrorMessageFn');
@@ -361,7 +372,7 @@ export default class BaseBuilder {
         x => !tcomb.String.is(getValidationErrorMessage(x)),
         name,
       );
-    }, name);
+    });
   }
 
   /**
@@ -370,8 +381,6 @@ export default class BaseBuilder {
    * sub-field options objects.
    *
    * @param {LazyTemplateInterface} provider
-   * @param {string} name - Identifier for the lazy template provider function;
-   * used internally to check builder equality
    * @return {BaseBuilder}
    */
   setLazyTemplateProvider(provider) {

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -171,6 +171,10 @@ export default class BaseBuilder {
    * @return {BaseBuilder}
    */
   setLazyTemplateFactory(name, callback) {
+    if (!tcomb.validate(name, tcomb.String).isValid()) {
+      throw new Error('First parameter must be a string');
+    }
+
     return new this.constructor(this._state
       .mergeIn(['builderFunctions', '_templateProviderCallback'], {
         name,
@@ -215,6 +219,10 @@ export default class BaseBuilder {
    * @return {BaseBuilder}
    */
   setValidation(name, getValidationErrorMessage) {
+    if (!tcomb.validate(name, tcomb.String).isValid()) {
+      throw new Error('First parameter must be a string');
+    }
+
     return new this.constructor(this._state
       .mergeIn(['builderFunctions', '_getValidationErrorMessage'], {
         name,
@@ -231,6 +239,10 @@ export default class BaseBuilder {
    * @return {BaseBuilder}
    */
   setTransformer(name, transformer) {
+    if (!tcomb.validate(name, tcomb.String).isValid()) {
+      throw new Error('First parameter must be a string');
+    }
+
     return new this.constructor(this._state
       .mergeIn(['optionsFunctions', 'transformer'], {
         name,
@@ -247,6 +259,10 @@ export default class BaseBuilder {
    * @return {BaseBuilder}
    */
   setSort(name, sortComparator) {
+    if (!tcomb.validate(name, tcomb.String).isValid()) {
+      throw new Error('First parameter must be a string');
+    }
+
     return new this.constructor(this._state
       .mergeIn(['configFunctions', 'sortComparator'], {
         name,
@@ -265,6 +281,10 @@ export default class BaseBuilder {
    * @return {BaseBuilder}
    */
   addValidation(name, getValidationErrorMessage) {
+    if (!tcomb.validate(name, tcomb.String).isValid()) {
+      throw new Error('First parameter must be a string');
+    }
+
     const existingFn = this._getBuilderFunction('_getValidationErrorMessage');
     if (!existingFn) {
       return this.setValidation(name, getValidationErrorMessage);
@@ -346,6 +366,10 @@ export default class BaseBuilder {
    * @return {BaseBuilder}
    */
   setType(name, typeCombinator) {
+    if (!tcomb.validate(name, tcomb.String).isValid()) {
+      throw new Error('First parameter must be a string');
+    }
+
     return new this.constructor(this._state
       .mergeIn(['builderFunctions', '_type'], {
         name,
@@ -362,6 +386,10 @@ export default class BaseBuilder {
    * @return {BaseBuilder}
    */
   setTypeAndValidate(name, type) {
+    if (!tcomb.validate(name, tcomb.String).isValid()) {
+      throw new Error('First parameter must be a string');
+    }
+
     return this.setType(name, getValidationErrorMessage => {
       if (!getValidationErrorMessage) {
         throw new Error('You called setTypeAndValidate without setting a '

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -363,10 +363,10 @@ export default class BaseBuilder {
    * @return {BaseBuilder}
    */
   setLazyTemplateProvider(provider, name) {
-    return new this.constructor(this._state.merge({
-      _lazyTemplateProvider: provider,
-      _lazyTemplateProviderName: name,
-    }));
+    // .merge() cannot be used here because it coerces provider into a Map.
+    return new this.constructor(this._state
+      .set('_lazyTemplateProvider', provider)
+      .set('_lazyTemplateProviderName', name));
   }
 
   /**
@@ -585,8 +585,6 @@ export default class BaseBuilder {
     // If a template callback exists, realize the template, merge any
     // sub-fields, and return the resulting options object.
     const templateProviderCallback = this._state.get('_templateProviderCallback');
-    console.log('provider: ', provider);
-    console.log(provider['setF1']);
     const options = !hasConcreteTemplateFactory && templateProviderCallback && !disableTemplates
       ? this._state.mergeDeep({ options: { factory: templateProviderCallback(provider) } })
       : this._state;

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -213,8 +213,10 @@ export default class BaseBuilder {
    */
   setValidation(getValidationErrorMessage, name) {
     return new this.constructor(this._state
-      .mergeIn(['builderFunctions', '_getValidationErrorMessage'],
-        { name, value: getValidationErrorMessage }));
+      .mergeIn(['builderFunctions', '_getValidationErrorMessage'], {
+        name,
+        value: getValidationErrorMessage,
+      }));
   }
 
   /**
@@ -263,7 +265,7 @@ export default class BaseBuilder {
       .setIn(['builderFunctions', '_getValidationErrorMessage', 'value'],
         validators.combine([existingFn, getValidationErrorMessage]))
       .updateIn(['builderFunctions', '_getValidationErrorMessage', 'name'],
-        oldName => (!oldName ? oldName : oldName + name)));
+        oldName => (oldName ? `${oldName} ${name}` : name)));
   }
 
   /**

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -95,7 +95,7 @@ describe('BaseBuilder', () => {
           }
           return 0;
         };
-        const builder = new BaseBuilder().setSort(sortComparator, 'LabelSort');
+        const builder = new BaseBuilder().setSort('LabelSort', sortComparator);
 
         expect(builder.getOptions().config).to.deep.equal({ sortComparator });
       });
@@ -167,8 +167,8 @@ describe('BaseBuilder', () => {
       it('can set a validation function', () => {
         const fn = () => { ({ foo: 'bar' }); };
         const builder = new BaseBuilder()
-          .setType(() => tcomb.String, 'String')
-          .setValidation(fn, 'FooBarValidation');
+          .setType('String', () => tcomb.String)
+          .setValidation('FooBarValidation', fn);
 
         expect(builder.getType().getValidationErrorMessage).to.equal(fn);
       });
@@ -177,7 +177,7 @@ describe('BaseBuilder', () => {
     describe('setTransformer()', () => {
       it('can set a transformer option function', () => {
         const fn = () => { ({ foo: 'bar' }); };
-        const builder = new BaseBuilder().setTransformer(fn, 'FooTransformer');
+        const builder = new BaseBuilder().setTransformer('FooTransformer', fn);
 
         expect(builder.getOptions()).to.deep.equal({ transformer: fn });
       });
@@ -188,8 +188,8 @@ describe('BaseBuilder', () => {
         it('sets the validation function', () => {
           const fn = items => (items.length > 1 ? null : 'Too short');
           const builder = new BaseBuilder()
-            .setType(() => tcomb.String, 'String')
-            .addValidation(fn, 'LengthValidation');
+            .setType('String', () => tcomb.String)
+            .addValidation('LengthValidation', fn);
           expect(builder.getType().getValidationErrorMessage(['a'])).to.equal('Too short');
         });
       });
@@ -200,12 +200,12 @@ describe('BaseBuilder', () => {
           const fn2 = items => (items[0] === 'foo' ? null : 'Wrong first element');
 
           const builder = new BaseBuilder()
-            .setType(() => tcomb.String, 'String')
-            .setValidation(fn1, 'LengthValidation');
+            .setType('String', () => tcomb.String)
+            .setValidation('LengthValidation', fn1);
 
           expect(builder.getType().getValidationErrorMessage(['a', 'b'])).to.equal(null);
 
-          const combinedBuilder = builder.addValidation(fn2, 'FirstElementValidation');
+          const combinedBuilder = builder.addValidation('FirstElementValidation', fn2);
 
           const combinedType = combinedBuilder.getType();
           expect(combinedType.getValidationErrorMessage(['a', 'b'])).to.contain('first');
@@ -295,7 +295,7 @@ describe('BaseBuilder', () => {
       context('a provider is not provided but a _templateCallback is', () => {
         it('throws if a _templateCallback is provided without a provider', () => {
           const builder = new BaseBuilder()
-            .setLazyTemplateFactory(provider => provider.doAThing(), 'AThing');
+            .setLazyTemplateFactory('AThing', provider => provider.doAThing());
 
           expect(() => builder.getOptions()).to.throw('no provider was set');
         });
@@ -321,12 +321,12 @@ describe('BaseBuilder', () => {
             setF3: () => { f3 = true; },
           };
           const field1 = new BaseBuilder()
-            .setLazyTemplateFactory(provider => provider.setF1(), 'F1');
+            .setLazyTemplateFactory('F1', provider => provider.setF1());
           const field2 = new BaseBuilder()
-            .setLazyTemplateFactory(provider => provider.setF2(), 'F2')
+            .setLazyTemplateFactory('F2', provider => provider.setF2())
             .setField('field1', field1);
           const field3 = new BaseBuilder()
-            .setLazyTemplateFactory(provider => provider.setF3(), 'F3');
+            .setLazyTemplateFactory('F3', provider => provider.setF3());
 
           const builder = new BaseBuilder()
             .setField('field2', field2)
@@ -350,7 +350,7 @@ describe('BaseBuilder', () => {
           const factory = 'factory';
           const builder = new BaseBuilder()
             .setTemplateFactory(factory)
-            .setLazyTemplateFactory(provider => provider.setF1(), 'F1')
+            .setLazyTemplateFactory('F1', provider => provider.setF1())
             .setLazyTemplateProvider(lazyTemplateProvider);
 
           const options = builder.getOptions();
@@ -398,7 +398,7 @@ describe('BaseBuilder', () => {
     describe('setTypeAndValidate', () => {
       it('requires an error message to be set before validation', () => {
         const builder = new BaseBuilder()
-          .setTypeAndValidate(tcomb.Any, 'myType');
+          .setTypeAndValidate('myType', tcomb.Any);
 
         expect(() => builder.getType()).to.throw();
       });
@@ -409,7 +409,7 @@ describe('BaseBuilder', () => {
     context('no sub-fields have been set', () => {
       context('no error message has been set', () => {
         it('returns the type of the current builder', () => {
-          const builder = new BaseBuilder().setType(() => tcomb.String, 'String');
+          const builder = new BaseBuilder().setType('String', () => tcomb.String);
 
           expect(builder.getType()).to.equal(tcomb.String);
         });
@@ -424,11 +424,11 @@ describe('BaseBuilder', () => {
     context('sub-fields have been set', () => {
       context('no builder types are dependent on the fieldset', () => {
         it('returns the type of only the top level builder', () => {
-          const field1 = new BaseBuilder().setType(() => tcomb.String, 'String');
-          const field2 = new BaseBuilder().setType(() => tcomb.String, 'String');
+          const field1 = new BaseBuilder().setType('String', () => tcomb.String);
+          const field2 = new BaseBuilder().setType('String', () => tcomb.String);
 
           const builder = new BaseBuilder()
-            .setType(() => tcomb.String, 'String')
+            .setType('String', () => tcomb.String)
             .setField('field1', field1)
             .setField('field2', field2);
 
@@ -440,18 +440,18 @@ describe('BaseBuilder', () => {
         it('returns the type of the builder with the context of the sub-fields', () => {
           const validation1 = () => 'foo';
           const field1 = new BaseBuilder()
-            .setValidation(validation1, 'FooValidation')
-            .setType(() => tcomb.String, 'String');
+            .setValidation('FooValidation', validation1)
+            .setType('String', () => tcomb.String);
 
           const validation2 = () => 'bar';
           const field2 = new BaseBuilder()
-            .setValidation(validation2, 'BarValidation')
-            .setType(() => tcomb.Number, 'Number');
+            .setValidation('BarValidation', validation2)
+            .setType('Number', () => tcomb.Number);
 
           const builderValidation = () => 'builder';
           const builder = new BaseBuilder()
-            .setType((error, fields) => ({ foo: fields }), 'Foo')
-            .setValidation(builderValidation, 'BuilderValidation')
+            .setType('Foo', (error, fields) => ({ foo: fields }))
+            .setValidation('BuilderValidation', builderValidation)
             .setField('field1', field1)
             .setField('field2', field2);
 
@@ -468,7 +468,7 @@ describe('BaseBuilder', () => {
         context('single field', () => {
           it('does not throw when no value is provided', () => {
             const type = new BaseBuilder()
-              .setType(() => tcomb.String, 'String')
+              .setType('String', () => tcomb.String)
               .makeOptional()
               .getType();
 
@@ -480,15 +480,15 @@ describe('BaseBuilder', () => {
         context('compound type', () => {
           it('does not throw when no value is provided', () => {
             const field1 = new BaseBuilder()
-              .setType(() => tcomb.String, 'String');
+              .setType('String', () => tcomb.String);
 
             const field2 = new BaseBuilder()
-              .setType(() => tcomb.String, 'String');
+              .setType('String', () => tcomb.String);
 
             const page = new BaseBuilder()
               .setField('field1', field1)
               .setField('field2', field2)
-              .setType((e, fields) => tcomb.struct(fields), 'FooStruct')
+              .setType('FooStruct', (e, fields) => tcomb.struct(fields))
               .makeOptional()
               .getType();
 
@@ -502,7 +502,7 @@ describe('BaseBuilder', () => {
         context('single field', () => {
           it('throws when no value is provided', () => {
             const type = new BaseBuilder()
-              .setType(() => tcomb.String, 'String')
+              .setType('String', () => tcomb.String)
               .getType();
 
             expect(() => type()).to.throw();
@@ -513,15 +513,15 @@ describe('BaseBuilder', () => {
         context('compound type', () => {
           it('throws when no value is provided', () => {
             const field1 = new BaseBuilder()
-              .setType(() => tcomb.String, 'String');
+              .setType('String', () => tcomb.String);
 
             const field2 = new BaseBuilder()
-              .setType(() => tcomb.String, 'String');
+              .setType('String', () => tcomb.String);
 
             const page = new BaseBuilder()
               .setField('field1', field1)
               .setField('field2', field2)
-              .setType((e, fields) => tcomb.struct(fields), 'FooStruct')
+              .setType('FooStruct', (e, fields) => tcomb.struct(fields))
               .getType();
 
             expect(() => page()).to.throw();
@@ -609,9 +609,9 @@ describe('BaseBuilder', () => {
       const factory1 = () => 'Error';
       const factory2 = () => 'Error';
       const builder1 = new BaseBuilder()
-        .setLazyTemplateFactory(factory1, 'Factory1');
+        .setLazyTemplateFactory('Factory1', factory1);
       const builder2 = new BaseBuilder()
-        .setLazyTemplateFactory(factory2, 'Factory1');
+        .setLazyTemplateFactory('Factory1', factory2);
 
       expect(builder1.isEqual(builder2)).to.be.true;
     });
@@ -622,9 +622,9 @@ describe('BaseBuilder', () => {
         const factory1 = () => 'Error';
         const factory2 = () => 'Error';
         const builder1 = new BaseBuilder()
-          .setLazyTemplateFactory(factory1, 'Factory1');
+          .setLazyTemplateFactory('Factory1', factory1);
         const builder2 = new BaseBuilder()
-          .setLazyTemplateFactory(factory2, 'Factory2');
+          .setLazyTemplateFactory('Factory2', factory2);
 
         expect(builder1.isEqual(builder2)).to.be.false;
       }
@@ -633,9 +633,9 @@ describe('BaseBuilder', () => {
         // Same function, different names.
         const factory = () => 'Error';
         const builder1 = new BaseBuilder()
-          .setLazyTemplateFactory(factory, 'Factory1');
+          .setLazyTemplateFactory('Factory1', factory);
         const builder2 = new BaseBuilder()
-          .setLazyTemplateFactory(factory, 'Factory2');
+          .setLazyTemplateFactory('Factory2', factory);
 
         expect(builder1.isEqual(builder2)).to.be.false;
       }
@@ -644,11 +644,11 @@ describe('BaseBuilder', () => {
     it('returns true if validation functions are set in the same order', () => {
       const error = () => 'Error';
       const builder1 = new BaseBuilder()
-        .setValidation(error, 'Error1')
-        .addValidation(error, 'Error2');
+        .setValidation('Error1', error)
+        .addValidation('Error2', error);
       const builder2 = new BaseBuilder()
-        .setValidation(error, 'Error1')
-        .addValidation(error, 'Error2');
+        .setValidation('Error1', error)
+        .addValidation('Error2', error);
 
       expect(builder1.isEqual(builder2)).to.be.true;
     });
@@ -656,11 +656,11 @@ describe('BaseBuilder', () => {
     it('returns false if validation functions are set in a different order', () => {
       const error = () => 'Error';
       const builder1 = new BaseBuilder()
-        .setValidation(error, 'Error1')
-        .addValidation(error, 'Error2');
+        .setValidation('Error1', error)
+        .addValidation('Error2', error);
       const builder2 = new BaseBuilder()
-        .setValidation(error, 'Error2')
-        .addValidation(error, 'Error1');
+        .setValidation('Error2', error)
+        .addValidation('Error1', error);
 
       expect(builder1.isEqual(builder2)).to.be.false;
     });
@@ -669,9 +669,9 @@ describe('BaseBuilder', () => {
       const transformer1 = () => 'Fn1';
       const transformer2 = () => 'Fn2';
       const builder1 = new BaseBuilder()
-        .setTransformer(transformer1, 'Transformer1');
+        .setTransformer('Transformer1', transformer1);
       const builder2 = new BaseBuilder()
-        .setTransformer(transformer2, 'Transformer1');
+        .setTransformer('Transformer1', transformer2);
 
       expect(builder1.isEqual(builder2)).to.be.true;
     });
@@ -680,9 +680,9 @@ describe('BaseBuilder', () => {
       const transformer1 = () => 'Fn1';
       const transformer2 = () => 'Fn2';
       const builder1 = new BaseBuilder()
-        .setTransformer(transformer1, 'Transformer1');
+        .setTransformer('Transformer1', transformer1);
       const builder2 = new BaseBuilder()
-        .setTransformer(transformer2, 'Transformer2');
+        .setTransformer('Transformer2', transformer2);
 
       expect(builder1.isEqual(builder2)).to.be.false;
     });
@@ -691,9 +691,9 @@ describe('BaseBuilder', () => {
       const comparator1 = () => 'Fn1';
       const comparator2 = () => 'Fn2';
       const builder1 = new BaseBuilder()
-        .setSort(comparator1, 'Comparator1');
+        .setSort('Comparator1', comparator1);
       const builder2 = new BaseBuilder()
-        .setSort(comparator2, 'Comparator1');
+        .setSort('Comparator1', comparator2);
 
       expect(builder1.isEqual(builder2)).to.be.true;
     });
@@ -702,9 +702,9 @@ describe('BaseBuilder', () => {
       const comparator1 = () => 'Fn1';
       const comparator2 = () => 'Fn2';
       const builder1 = new BaseBuilder()
-        .setSort(comparator1, 'Comparator1');
+        .setSort('Comparator1', comparator1);
       const builder2 = new BaseBuilder()
-        .setSort(comparator2, 'Comparator2');
+        .setSort('Comparator2', comparator2);
 
       expect(builder1.isEqual(builder2)).to.be.false;
     });

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -564,5 +564,23 @@ describe('BaseBuilder', () => {
 
       expect(builder1.isEqual(builder2)).to.be.false;
     });
+
+    it('can compare inequivalent builders', () => {
+      const builder1 = new BaseBuilder().setLabel('Foo');
+      const builder2 = new BaseBuilder().setLabel('Bar');
+
+      expect(builder1.isEqual(builder2)).to.be.false;
+    });
+
+    it('can compare inequivalent builders', () => {
+      const error = () => 'Error';
+      const error2 = () => null;
+      const builder1 = new BaseBuilder()
+        .setValidationErrorMessageFn(error);
+      const builder2 = new BaseBuilder()
+        .setValidationErrorMessageFn(error2);
+
+      expect(builder1.isEqual(builder2)).to.be.false;
+    });
   });
 });

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -576,9 +576,9 @@ describe('BaseBuilder', () => {
       const error = () => 'Error';
       const error2 = () => null;
       const builder1 = new BaseBuilder()
-        .setValidationErrorMessageFn(error);
+        .setValidation(error);
       const builder2 = new BaseBuilder()
-        .setValidationErrorMessageFn(error2);
+        .setValidation(error2);
 
       expect(builder1.isEqual(builder2)).to.be.false;
     });

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -529,4 +529,40 @@ describe('BaseBuilder', () => {
       });
     });
   });
+
+  describe('isEqual()', () => {
+    it('returns true with passed the same instance', () => {
+      const builder = new BaseBuilder();
+      expect(builder.isEqual(builder)).to.be.true;
+    });
+
+    it('can compare equivalent builders', () => {
+      const builder = new BaseBuilder();
+      expect(builder.isEqual(builder)).to.be.true;
+    });
+
+    it('can compare equivalent builders', () => {
+      const builder1 = new BaseBuilder()
+        .setField('subfield1', new BaseBuilder())
+        .setField('subfield2', new BaseBuilder());
+      const builder2 = new BaseBuilder()
+        .setField('subfield1', new BaseBuilder())
+        .setField('subfield2', new BaseBuilder());
+
+      expect(builder1.isEqual(builder2)).to.be.true;
+    });
+
+    it('can compare inequivalent builders', () => {
+      const builder1 = new BaseBuilder()
+        .setField('subfield1', new BaseBuilder()
+          .setConfig({ foo: 'bar' }))
+        .setField('subfield2', new BaseBuilder());
+      const builder2 = new BaseBuilder()
+        .setField('subfield1', new BaseBuilder()
+          .setConfig({ foo: 'baz' }))
+        .setField('subfield2', new BaseBuilder());
+
+      expect(builder1.isEqual(builder2)).to.be.false;
+    });
+  });
 });

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -333,7 +333,6 @@ describe('BaseBuilder', () => {
             .setField('field3', field3)
             .setLazyTemplateProvider(lazyTemplateProvider, 'DefaultProvider');
 
-          console.log('Start provider test');
           builder.getOptions();
 
           expect(f1).to.be.true;

--- a/src/__tests__/BaseBuilder.spec.js
+++ b/src/__tests__/BaseBuilder.spec.js
@@ -304,7 +304,7 @@ describe('BaseBuilder', () => {
       context('a provider is provided but a _templateCallback is not', () => {
         it('does not throw', () => {
           const builder = new BaseBuilder()
-            .setLazyTemplateProvider('blah', 'BlahProvider');
+            .setLazyTemplateProvider('blah');
 
           expect(() => builder.getOptions()).to.not.throw();
         });
@@ -331,7 +331,7 @@ describe('BaseBuilder', () => {
           const builder = new BaseBuilder()
             .setField('field2', field2)
             .setField('field3', field3)
-            .setLazyTemplateProvider(lazyTemplateProvider, 'DefaultProvider');
+            .setLazyTemplateProvider(lazyTemplateProvider);
 
           builder.getOptions();
 
@@ -351,7 +351,7 @@ describe('BaseBuilder', () => {
           const builder = new BaseBuilder()
             .setTemplateFactory(factory)
             .setLazyTemplateFactory(provider => provider.setF1(), 'F1')
-            .setLazyTemplateProvider(lazyTemplateProvider, 'DefaultProvider');
+            .setLazyTemplateProvider(lazyTemplateProvider);
 
           const options = builder.getOptions();
           expect(options.factory).to.equal(factory);

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -9,7 +9,7 @@ import {
 
 describe('index sanity test', () => {
   describe('provider can be accessed from a builder', () => {
-    const builder = CharacterProfileBuilder.setLazyTemplateProvider(mockProvider);
+    const builder = CharacterProfileBuilder.setLazyTemplateProvider(mockProvider, 'MockProvider');
     expect(() => builder.getType()).to.not.throw();
     expect(() => builder.getOptions()).to.not.throw();
   });

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -9,7 +9,7 @@ import {
 
 describe('index sanity test', () => {
   describe('provider can be accessed from a builder', () => {
-    const builder = CharacterProfileBuilder.setLazyTemplateProvider(mockProvider, 'MockProvider');
+    const builder = CharacterProfileBuilder.setLazyTemplateProvider(mockProvider);
     expect(() => builder.getType()).to.not.throw();
     expect(() => builder.getOptions()).to.not.throw();
   });

--- a/src/combinators.js
+++ b/src/combinators.js
@@ -1,5 +1,0 @@
-import tcomb from 'tcomb-validation';
-
-export function validation(type, getValidationErrorMessage, name) {
-  return tcomb.refinement(type, x => !tcomb.String.is(getValidationErrorMessage(x)), name);
-}

--- a/src/examples/CharacterProfileBuilder.js
+++ b/src/examples/CharacterProfileBuilder.js
@@ -3,7 +3,7 @@ import { validators, widgets } from '../index';
 const name = widgets.TextBuilder.setLabel('Name');
 
 const dateOfBirth = widgets.TextBuilder
-  .setValidation(validators.date.birthdate)
+  .setValidation(validators.date.birthdate, 'BirthdateValidation')
   .setLabel('Date of Birth');
 
 const occupation = widgets.TextBuilder
@@ -26,7 +26,7 @@ const crossValidation = validators.combine([
 ]);
 
 const foodGroup = widgets.CheckboxGroupBuilder
-  .setValidation(crossValidation)
+  .setValidation(crossValidation, 'CrossValidation')
   .setField('bananaStand', bananaStand)
   .setField('chickenDance', chickenDance)
   .setField('hugeMistake', hugeMistake)

--- a/src/examples/CharacterProfileBuilder.js
+++ b/src/examples/CharacterProfileBuilder.js
@@ -3,7 +3,7 @@ import { validators, widgets } from '../index';
 const name = widgets.TextBuilder.setLabel('Name');
 
 const dateOfBirth = widgets.TextBuilder
-  .setValidation(validators.date.birthdate, 'BirthdateValidation')
+  .setValidation('BirthdateValidation', validators.date.birthdate)
   .setLabel('Date of Birth');
 
 const occupation = widgets.TextBuilder
@@ -26,7 +26,7 @@ const crossValidation = validators.combine([
 ]);
 
 const foodGroup = widgets.CheckboxGroupBuilder
-  .setValidation(crossValidation, 'CrossValidation')
+  .setValidation('CrossValidation', crossValidation)
   .setField('bananaStand', bananaStand)
   .setField('chickenDance', chickenDance)
   .setField('hugeMistake', hugeMistake)

--- a/src/examples/TelevisionShowBuilder.js
+++ b/src/examples/TelevisionShowBuilder.js
@@ -3,7 +3,7 @@ import { validators, widgets } from '../index';
 const showName = widgets.TextBuilder.setLabel('Show Name');
 
 const firstEpisodeDate = widgets.TextBuilder
-  .setValidation(validators.date.birthdate, 'BirthdateValidation')
+  .setValidation('BirthdateValidation', validators.date.birthdate)
   .setLabel('Date of Birth');
 
 const genre = widgets.TextBuilder

--- a/src/examples/TelevisionShowBuilder.js
+++ b/src/examples/TelevisionShowBuilder.js
@@ -3,7 +3,7 @@ import { validators, widgets } from '../index';
 const showName = widgets.TextBuilder.setLabel('Show Name');
 
 const firstEpisodeDate = widgets.TextBuilder
-  .setValidation(validators.date.birthdate)
+  .setValidation(validators.date.birthdate, 'BirthdateValidation')
   .setLabel('Date of Birth');
 
 const genre = widgets.TextBuilder

--- a/src/primitives/CheckboxBuilder.js
+++ b/src/primitives/CheckboxBuilder.js
@@ -4,5 +4,5 @@ import BaseBuilder from '../BaseBuilder';
 import * as validators from '../validators';
 
 export default new BaseBuilder()
-  .setValidation(validators.checkbox.isBoolean)
+  .setValidation(validators.checkbox.isBoolean, 'BooleanValidation')
   .setTypeAndValidate(tcomb.Boolean, 'Checkbox');

--- a/src/primitives/CheckboxBuilder.js
+++ b/src/primitives/CheckboxBuilder.js
@@ -4,5 +4,5 @@ import BaseBuilder from '../BaseBuilder';
 import * as validators from '../validators';
 
 export default new BaseBuilder()
-  .setValidation(validators.checkbox.isBoolean, 'BooleanValidation')
-  .setTypeAndValidate(tcomb.Boolean, 'Checkbox');
+  .setValidation('BooleanValidation', validators.checkbox.isBoolean)
+  .setTypeAndValidate('Checkbox', tcomb.Boolean);

--- a/src/primitives/NumberBuilder.js
+++ b/src/primitives/NumberBuilder.js
@@ -4,5 +4,5 @@ import BaseBuilder from '../BaseBuilder';
 import * as validators from '../validators';
 
 export default new BaseBuilder()
-  .setTypeAndValidate(tcomb.Number, 'Number')
-  .setValidation(validators.number.isNumber, 'NumberValidation');
+  .setTypeAndValidate('Number', tcomb.Number)
+  .setValidation('NumberValidation', validators.number.isNumber);

--- a/src/primitives/NumberBuilder.js
+++ b/src/primitives/NumberBuilder.js
@@ -3,10 +3,6 @@ import tcomb from 'tcomb-validation';
 import BaseBuilder from '../BaseBuilder';
 import * as validators from '../validators';
 
-const validation = validators.combine([
-  validators.number.isNumber,
-]);
-
 export default new BaseBuilder()
   .setTypeAndValidate(tcomb.Number, 'Number')
-  .setValidation(validation);
+  .setValidation(validators.number.isNumber, 'NumberValidation');

--- a/src/primitives/SelectBuilder.js
+++ b/src/primitives/SelectBuilder.js
@@ -16,9 +16,9 @@ class SelectBuilder extends BaseBuilder {
       ? tcomb.enums.of(choices)
       : tcomb.enums(choices);
 
-    return this.setTypeAndValidate(typeEnum, 'Select');
+    return this.setTypeAndValidate('Select', typeEnum);
   }
 }
 
 export default new SelectBuilder()
-  .setValidation(validators.shared.hasSelection, 'SelectionValidation');
+  .setValidation('SelectionValidation', validators.shared.hasSelection);

--- a/src/primitives/SelectBuilder.js
+++ b/src/primitives/SelectBuilder.js
@@ -21,4 +21,4 @@ class SelectBuilder extends BaseBuilder {
 }
 
 export default new SelectBuilder()
-  .setValidation(validators.shared.hasSelection);
+  .setValidation(validators.shared.hasSelection, 'SelectionValidation');

--- a/src/primitives/StructBuilder.js
+++ b/src/primitives/StructBuilder.js
@@ -1,7 +1,6 @@
 import tcomb from 'tcomb-validation';
 
 import BaseBuilder from '../BaseBuilder';
-import { validation } from '../combinators';
 
 
 class StructBuilder extends BaseBuilder {
@@ -17,5 +16,8 @@ class StructBuilder extends BaseBuilder {
 }
 
 export default new StructBuilder()
-  .setValidation(() => null)
-  .setType((errorFn, fields) => validation(tcomb.struct(fields), errorFn, 'Struct'));
+  .setValidation(() => null, 'NoValidation')
+  .setType((getValidationErrorMessage, fields) => tcomb.refinement(
+    tcomb.struct(fields), x => !tcomb.String.is(getValidationErrorMessage(x)), 'Struct',
+    'Struct',
+  ));

--- a/src/primitives/StructBuilder.js
+++ b/src/primitives/StructBuilder.js
@@ -16,8 +16,6 @@ class StructBuilder extends BaseBuilder {
 }
 
 export default new StructBuilder()
-  .setValidation(() => null, 'NoValidation')
-  .setType((getValidationErrorMessage, fields) => tcomb.refinement(
-    tcomb.struct(fields), x => !tcomb.String.is(getValidationErrorMessage(x)), 'Struct',
-    'Struct',
-  ));
+  .setValidation('NoValidation', () => null)
+  .setType('Struct', (getValidationErrorMessage, fields) => tcomb.refinement(
+    tcomb.struct(fields), x => !tcomb.String.is(getValidationErrorMessage(x)), 'Struct'));

--- a/src/primitives/TextBuilder.js
+++ b/src/primitives/TextBuilder.js
@@ -10,4 +10,4 @@ const validation = validators.combine([
 
 export default new BaseBuilder()
   .setTypeAndValidate(tcomb.String, 'Text')
-  .setValidation(validation);
+  .setValidation(validation, 'LengthValidation');

--- a/src/primitives/TextBuilder.js
+++ b/src/primitives/TextBuilder.js
@@ -9,5 +9,5 @@ const validation = validators.combine([
 ]);
 
 export default new BaseBuilder()
-  .setTypeAndValidate(tcomb.String, 'Text')
-  .setValidation(validation, 'LengthValidation');
+  .setTypeAndValidate('Text', tcomb.String)
+  .setValidation('LengthValidation', validation);

--- a/src/primitives/UnionBuilder.js
+++ b/src/primitives/UnionBuilder.js
@@ -28,8 +28,15 @@ class UnionBuilder extends BaseBuilder {
    *
    * @param {function} dispatch
    */
-  setDispatch(dispatch) {
-    return new this.constructor(this._state.set('_dispatch', dispatch));
+  setDispatch(dispatch, name) {
+    return new this.constructor(this._state.mergeDeep({
+      builderFunctions: {
+        _dispatch: {
+          name,
+          value: dispatch,
+        },
+      },
+    }));
   }
 }
 

--- a/src/primitives/UnionBuilder.js
+++ b/src/primitives/UnionBuilder.js
@@ -28,7 +28,7 @@ class UnionBuilder extends BaseBuilder {
    *
    * @param {function} dispatch
    */
-  setDispatch(dispatch, name) {
+  setDispatch(name, dispatch) {
     return new this.constructor(this._state
       .mergeIn(['builderFunctions', '_dispatch'], { name, value: dispatch }));
   }

--- a/src/primitives/UnionBuilder.js
+++ b/src/primitives/UnionBuilder.js
@@ -29,14 +29,8 @@ class UnionBuilder extends BaseBuilder {
    * @param {function} dispatch
    */
   setDispatch(dispatch, name) {
-    return new this.constructor(this._state.mergeDeep({
-      builderFunctions: {
-        _dispatch: {
-          name,
-          value: dispatch,
-        },
-      },
-    }));
+    return new this.constructor(this._state
+      .mergeIn(['builderFunctions', '_dispatch'], { name, value: dispatch }));
   }
 }
 

--- a/src/primitives/__tests__/UnionBuilder.spec.js
+++ b/src/primitives/__tests__/UnionBuilder.spec.js
@@ -77,4 +77,32 @@ describe('UnionBuilder', () => {
       expect(() => UnionBuilder.setField(TextBuilder)).to.throw();
     });
   });
+
+  describe('isEqual', () => {
+    it('can compare inequivalent builders', () => {
+      const international = StructBuilder
+        .setField('country', TextBuilder);
+      const usa = StructBuilder
+        .setField('country', TextBuilder)
+        .setField('state', TextBuilder);
+      const countriesBuilder = UnionBuilder
+        .setUnion([international, usa])
+        .setDispatch(value => (
+          value.country === 'usa' ? usa : international
+        ));
+
+      const otherInternational = StructBuilder
+        .setField('country', TextBuilder);
+      const otherUsa = StructBuilder
+        .setField('country', TextBuilder)
+        .setField('state', TextBuilder);
+      const otherCountriesBuilder = UnionBuilder
+        .setUnion([otherInternational, otherUsa])
+        .setDispatch(value => (
+          value.country === 'usa' ? otherUsa : otherInternational
+        ));
+
+      expect(countriesBuilder.isEqual(otherCountriesBuilder)).to.be.true;
+    });
+  });
 });

--- a/src/primitives/__tests__/UnionBuilder.spec.js
+++ b/src/primitives/__tests__/UnionBuilder.spec.js
@@ -13,9 +13,9 @@ describe('UnionBuilder', () => {
         .setField('state', TextBuilder);
       const countriesBuilder = UnionBuilder
         .setUnion([international, usa])
-        .setDispatch(value => (
+        .setDispatch('CountryDispatch', value => (
           value.country === 'usa' ? usa : international
-        ), 'CountryDispatch');
+        ));
       const Country = countriesBuilder.getType();
       expect(() => Country({ country: 'usa', state: 'california' })).to.not.throw();
       expect(() => Country({ country: 'usa' })).to.throw();
@@ -30,9 +30,9 @@ describe('UnionBuilder', () => {
         .setField('state', TextBuilder);
       const countriesBuilder = UnionBuilder
         .setUnion([international, usa])
-        .setDispatch(value => (
+        .setDispatch('CountryDispatch', value => (
           value.country === 'usa' ? usa : international
-        ), 'CountryDispatch');
+        ));
       expect(countriesBuilder.getOptions()).to.have.length(2);
     });
 
@@ -47,9 +47,9 @@ describe('UnionBuilder', () => {
         .setField('state', TextBuilder);
       const countriesBuilder = UnionBuilder
         .setUnion([international, usa])
-        .setDispatch(value => (
+        .setDispatch('CountryDispatch', value => (
           value.country === 'usa' ? imposterUsa : international
-        ), 'CountryDispatch');
+        ));
       const Country = countriesBuilder.getType();
       expect(() => Country({ country: 'usa', state: 'california' })).to.throw();
     });
@@ -64,9 +64,9 @@ describe('UnionBuilder', () => {
       const countriesBuilder = UnionBuilder
         ._disableTemplates()
         .setUnion([international, usa])
-        .setDispatch(value => (
+        .setDispatch('CountryDispatch', value => (
           value.country === 'usa' ? usa : international
-        ), 'CountryDispatch');
+        ));
       expect(() => countriesBuilder.getOptions()).to.not.throw();
       expect(countriesBuilder.getOptions()).to.have.length(2);
     });
@@ -87,9 +87,9 @@ describe('UnionBuilder', () => {
         .setField('state', TextBuilder);
       const countriesBuilder = UnionBuilder
         .setUnion([international, usa])
-        .setDispatch(value => (
+        .setDispatch('CountryDispatch', value => (
           value.country === 'usa' ? usa : international
-        ), 'CountryDispatch');
+        ));
 
       const otherInternational = StructBuilder
         .setField('country', TextBuilder);
@@ -98,9 +98,9 @@ describe('UnionBuilder', () => {
         .setField('state', TextBuilder);
       const otherCountriesBuilder = UnionBuilder
         .setUnion([otherInternational, otherUsa])
-        .setDispatch(value => (
+        .setDispatch('CountryDispatch', value => (
           value.country === 'usa' ? otherUsa : otherInternational
-        ), 'CountryDispatch');
+        ));
 
       expect(countriesBuilder.isEqual(otherCountriesBuilder)).to.be.true;
     });
@@ -115,9 +115,9 @@ describe('UnionBuilder', () => {
         .setField('zip', TextBuilder);
       const countriesBuilder = UnionBuilder
         .setUnion([international, usa])
-        .setDispatch(value => (
+        .setDispatch('CountryDispatch', value => (
           value.country === 'usa' ? usa : international
-        ), 'CountryDispatch');
+        ));
 
       // Usa does not have zip.
       const otherInternational = StructBuilder
@@ -127,9 +127,9 @@ describe('UnionBuilder', () => {
         .setField('state', TextBuilder);
       const otherCountriesBuilder = UnionBuilder
         .setUnion([otherInternational, otherUsa])
-        .setDispatch(value => (
+        .setDispatch('CountryDispatch', value => (
           value.country === 'usa' ? otherUsa : otherInternational
-        ), 'CountryDispatch');
+        ));
 
       expect(countriesBuilder.isEqual(otherCountriesBuilder)).to.be.false;
     });

--- a/src/primitives/__tests__/UnionBuilder.spec.js
+++ b/src/primitives/__tests__/UnionBuilder.spec.js
@@ -15,7 +15,7 @@ describe('UnionBuilder', () => {
         .setUnion([international, usa])
         .setDispatch(value => (
           value.country === 'usa' ? usa : international
-        ));
+        ), 'CountryDispatch');
       const Country = countriesBuilder.getType();
       expect(() => Country({ country: 'usa', state: 'california' })).to.not.throw();
       expect(() => Country({ country: 'usa' })).to.throw();
@@ -32,7 +32,7 @@ describe('UnionBuilder', () => {
         .setUnion([international, usa])
         .setDispatch(value => (
           value.country === 'usa' ? usa : international
-        ));
+        ), 'CountryDispatch');
       expect(countriesBuilder.getOptions()).to.have.length(2);
     });
 
@@ -49,7 +49,7 @@ describe('UnionBuilder', () => {
         .setUnion([international, usa])
         .setDispatch(value => (
           value.country === 'usa' ? imposterUsa : international
-        ));
+        ), 'CountryDispatch');
       const Country = countriesBuilder.getType();
       expect(() => Country({ country: 'usa', state: 'california' })).to.throw();
     });
@@ -66,7 +66,7 @@ describe('UnionBuilder', () => {
         .setUnion([international, usa])
         .setDispatch(value => (
           value.country === 'usa' ? usa : international
-        ));
+        ), 'CountryDispatch');
       expect(() => countriesBuilder.getOptions()).to.not.throw();
       expect(countriesBuilder.getOptions()).to.have.length(2);
     });
@@ -89,7 +89,7 @@ describe('UnionBuilder', () => {
         .setUnion([international, usa])
         .setDispatch(value => (
           value.country === 'usa' ? usa : international
-        ));
+        ), 'CountryDispatch');
 
       const otherInternational = StructBuilder
         .setField('country', TextBuilder);
@@ -100,7 +100,7 @@ describe('UnionBuilder', () => {
         .setUnion([otherInternational, otherUsa])
         .setDispatch(value => (
           value.country === 'usa' ? otherUsa : otherInternational
-        ));
+        ), 'CountryDispatch');
 
       expect(countriesBuilder.isEqual(otherCountriesBuilder)).to.be.true;
     });
@@ -117,7 +117,7 @@ describe('UnionBuilder', () => {
         .setUnion([international, usa])
         .setDispatch(value => (
           value.country === 'usa' ? usa : international
-        ));
+        ), 'CountryDispatch');
 
       // Usa does not have zip.
       const otherInternational = StructBuilder
@@ -129,7 +129,7 @@ describe('UnionBuilder', () => {
         .setUnion([otherInternational, otherUsa])
         .setDispatch(value => (
           value.country === 'usa' ? otherUsa : otherInternational
-        ));
+        ), 'CountryDispatch');
 
       expect(countriesBuilder.isEqual(otherCountriesBuilder)).to.be.false;
     });

--- a/src/primitives/__tests__/UnionBuilder.spec.js
+++ b/src/primitives/__tests__/UnionBuilder.spec.js
@@ -79,7 +79,7 @@ describe('UnionBuilder', () => {
   });
 
   describe('isEqual', () => {
-    it('can compare inequivalent builders', () => {
+    it('returns true if all unions are equal', () => {
       const international = StructBuilder
         .setField('country', TextBuilder);
       const usa = StructBuilder
@@ -103,6 +103,35 @@ describe('UnionBuilder', () => {
         ));
 
       expect(countriesBuilder.isEqual(otherCountriesBuilder)).to.be.true;
+    });
+
+    it('returns false if any unions are not equal', () => {
+      // Usa has zip.
+      const international = StructBuilder
+        .setField('country', TextBuilder);
+      const usa = StructBuilder
+        .setField('country', TextBuilder)
+        .setField('state', TextBuilder)
+        .setField('zip', TextBuilder);
+      const countriesBuilder = UnionBuilder
+        .setUnion([international, usa])
+        .setDispatch(value => (
+          value.country === 'usa' ? usa : international
+        ));
+
+      // Usa does not have zip.
+      const otherInternational = StructBuilder
+        .setField('country', TextBuilder);
+      const otherUsa = StructBuilder
+        .setField('country', TextBuilder)
+        .setField('state', TextBuilder);
+      const otherCountriesBuilder = UnionBuilder
+        .setUnion([otherInternational, otherUsa])
+        .setDispatch(value => (
+          value.country === 'usa' ? otherUsa : otherInternational
+        ));
+
+      expect(countriesBuilder.isEqual(otherCountriesBuilder)).to.be.false;
     });
   });
 });

--- a/src/widgets/CheckboxBuilder.js
+++ b/src/widgets/CheckboxBuilder.js
@@ -1,4 +1,4 @@
 import CheckboxBuilder from '../primitives/CheckboxBuilder';
 
 export default CheckboxBuilder
-  .setLazyTemplateFactory(provider => provider.getCheckbox(), 'Checkbox');
+  .setLazyTemplateFactory('Checkbox', provider => provider.getCheckbox());

--- a/src/widgets/CheckboxBuilder.js
+++ b/src/widgets/CheckboxBuilder.js
@@ -1,4 +1,4 @@
 import CheckboxBuilder from '../primitives/CheckboxBuilder';
 
 export default CheckboxBuilder
-  .setLazyTemplateFactory(provider => provider.getCheckbox());
+  .setLazyTemplateFactory(provider => provider.getCheckbox(), 'Checkbox');

--- a/src/widgets/CheckboxGroupBuilder.js
+++ b/src/widgets/CheckboxGroupBuilder.js
@@ -1,4 +1,4 @@
 import StructBuilder from '../primitives/StructBuilder';
 
 export default StructBuilder
-  .setLazyTemplateFactory(provider => provider.getCheckboxGroup(), 'CheckboxGroup');
+  .setLazyTemplateFactory('CheckboxGroup', provider => provider.getCheckboxGroup());

--- a/src/widgets/CheckboxGroupBuilder.js
+++ b/src/widgets/CheckboxGroupBuilder.js
@@ -1,4 +1,4 @@
 import StructBuilder from '../primitives/StructBuilder';
 
 export default StructBuilder
-  .setLazyTemplateFactory(provider => provider.getCheckboxGroup());
+  .setLazyTemplateFactory(provider => provider.getCheckboxGroup(), 'CheckboxGroup');

--- a/src/widgets/DropDownBuilder.js
+++ b/src/widgets/DropDownBuilder.js
@@ -2,5 +2,5 @@ import SelectBuilder from '../primitives/SelectBuilder';
 import * as validators from '../validators';
 
 export default SelectBuilder
-  .setValidation(validators.shared.hasSelection, 'SelectionValidation')
-  .setLazyTemplateFactory(provider => provider.getDropDown(), 'DropDown');
+  .setValidation('SelectionValidation', validators.shared.hasSelection)
+  .setLazyTemplateFactory('DropDown', provider => provider.getDropDown());

--- a/src/widgets/DropDownBuilder.js
+++ b/src/widgets/DropDownBuilder.js
@@ -2,5 +2,5 @@ import SelectBuilder from '../primitives/SelectBuilder';
 import * as validators from '../validators';
 
 export default SelectBuilder
-  .setValidation(validators.shared.hasSelection)
-  .setLazyTemplateFactory(provider => provider.getDropDown());
+  .setValidation(validators.shared.hasSelection, 'SelectionValidation')
+  .setLazyTemplateFactory(provider => provider.getDropDown(), 'DropDown');

--- a/src/widgets/NumberBuilder.js
+++ b/src/widgets/NumberBuilder.js
@@ -9,5 +9,5 @@ const numberTransformer = {
 };
 
 export default NumberBuilder
-  .setTransformer(numberTransformer, 'NumberTransformer')
-  .setLazyTemplateFactory(provider => provider.getTextField(), 'TextField');
+  .setTransformer('NumberTransformer', numberTransformer)
+  .setLazyTemplateFactory('TextField', provider => provider.getTextField());

--- a/src/widgets/NumberBuilder.js
+++ b/src/widgets/NumberBuilder.js
@@ -9,5 +9,5 @@ const numberTransformer = {
 };
 
 export default NumberBuilder
-  .setTransformer(numberTransformer)
-  .setLazyTemplateFactory(provider => provider.getTextField());
+  .setTransformer(numberTransformer, 'NumberTransformer')
+  .setLazyTemplateFactory(provider => provider.getTextField(), 'TextField');

--- a/src/widgets/RadioBuilder.js
+++ b/src/widgets/RadioBuilder.js
@@ -17,5 +17,5 @@ class RadioBuilder extends SelectBuilder.constructor {
 }
 
 export default new RadioBuilder()
-  .setValidation(validators.shared.hasSelection)
-  .setLazyTemplateFactory(provider => provider.getRadio());
+  .setValidation(validators.shared.hasSelection, 'SelectionValidation')
+  .setLazyTemplateFactory(provider => provider.getRadio(), 'Radio');

--- a/src/widgets/RadioBuilder.js
+++ b/src/widgets/RadioBuilder.js
@@ -17,5 +17,5 @@ class RadioBuilder extends SelectBuilder.constructor {
 }
 
 export default new RadioBuilder()
-  .setValidation(validators.shared.hasSelection, 'SelectionValidation')
-  .setLazyTemplateFactory(provider => provider.getRadio(), 'Radio');
+  .setValidation('SelectionValidation', validators.shared.hasSelection)
+  .setLazyTemplateFactory('Radio', provider => provider.getRadio());

--- a/src/widgets/StaticPageBuilder.js
+++ b/src/widgets/StaticPageBuilder.js
@@ -3,7 +3,7 @@ import tcomb from 'tcomb-validation';
 import BaseBuilder from '../BaseBuilder';
 
 export default new BaseBuilder()
-  .setValidation(() => null)
+  .setValidation(() => null, 'NoValidation')
   .setTypeAndValidate(tcomb.Any, 'Static Text')
-  .setLazyTemplateFactory(provider => provider.getStaticPage());
+  .setLazyTemplateFactory(provider => provider.getStaticPage(), 'StaticPage');
 

--- a/src/widgets/StaticPageBuilder.js
+++ b/src/widgets/StaticPageBuilder.js
@@ -3,7 +3,7 @@ import tcomb from 'tcomb-validation';
 import BaseBuilder from '../BaseBuilder';
 
 export default new BaseBuilder()
-  .setValidation(() => null, 'NoValidation')
-  .setTypeAndValidate(tcomb.Any, 'Static Text')
-  .setLazyTemplateFactory(provider => provider.getStaticPage(), 'StaticPage');
+  .setValidation('NoValidation', () => null)
+  .setTypeAndValidate('Static Text', tcomb.Any)
+  .setLazyTemplateFactory('StaticPage', provider => provider.getStaticPage());
 

--- a/src/widgets/StructBuilder.js
+++ b/src/widgets/StructBuilder.js
@@ -1,5 +1,5 @@
 import StructBuilder from '../primitives/StructBuilder';
 
 export default StructBuilder
-  .setLazyTemplateFactory(provider => provider.getStruct());
+  .setLazyTemplateFactory(provider => provider.getStruct(), 'Struct');
 

--- a/src/widgets/StructBuilder.js
+++ b/src/widgets/StructBuilder.js
@@ -1,5 +1,5 @@
 import StructBuilder from '../primitives/StructBuilder';
 
 export default StructBuilder
-  .setLazyTemplateFactory(provider => provider.getStruct(), 'Struct');
+  .setLazyTemplateFactory('Struct', provider => provider.getStruct());
 

--- a/src/widgets/TextAreaBuilder.js
+++ b/src/widgets/TextAreaBuilder.js
@@ -1,4 +1,4 @@
 import TextBuilder from '../primitives/TextBuilder';
 
 export default TextBuilder
-  .setLazyTemplateFactory(provider => provider.getTextArea());
+  .setLazyTemplateFactory(provider => provider.getTextArea(), 'TextArea');

--- a/src/widgets/TextAreaBuilder.js
+++ b/src/widgets/TextAreaBuilder.js
@@ -1,4 +1,4 @@
 import TextBuilder from '../primitives/TextBuilder';
 
 export default TextBuilder
-  .setLazyTemplateFactory(provider => provider.getTextArea(), 'TextArea');
+  .setLazyTemplateFactory('TextArea', provider => provider.getTextArea());

--- a/src/widgets/TextBuilder.js
+++ b/src/widgets/TextBuilder.js
@@ -1,4 +1,4 @@
 import TextBuilder from '../primitives/TextBuilder';
 
 export default TextBuilder
-  .setLazyTemplateFactory(provider => provider.getTextField());
+  .setLazyTemplateFactory(provider => provider.getTextField(), 'TextField');

--- a/src/widgets/TextBuilder.js
+++ b/src/widgets/TextBuilder.js
@@ -1,4 +1,4 @@
 import TextBuilder from '../primitives/TextBuilder';
 
 export default TextBuilder
-  .setLazyTemplateFactory(provider => provider.getTextField(), 'TextField');
+  .setLazyTemplateFactory('TextField', provider => provider.getTextField());

--- a/src/widgets/__tests__/CheckboxGroupBuilder.spec.js
+++ b/src/widgets/__tests__/CheckboxGroupBuilder.spec.js
@@ -7,7 +7,7 @@ const b = CheckboxBuilder.setLabel('b');
 const c = CheckboxBuilder.setLabel('c');
 
 const checkboxGroupBuilder = CheckboxGroupBuilder
-  .setValidation(validators.checkbox.minMax({ min: 0, max: 2 }))
+  .setValidation(validators.checkbox.minMax({ min: 0, max: 2 }), 'MinMaxValidation')
   .setField('a', a)
   .setField('b', b)
   .setField('c', c);
@@ -15,7 +15,7 @@ const checkboxGroupBuilder = CheckboxGroupBuilder
 describe('CheckboxGroupBuilder', () => {
   it('produces a tcomb Struct that validates correctly', () => {
     const CheckboxGroupType = checkboxGroupBuilder
-      .setValidation(validators.checkbox.minMax({ min: 0, max: 3 }))
+      .setValidation(validators.checkbox.minMax({ min: 0, max: 3 }), 'MinMaxValidation')
       .getType();
     const CheckboxType = CheckboxBuilder.getType();
     const selections = {
@@ -29,7 +29,7 @@ describe('CheckboxGroupBuilder', () => {
 
   it('produces an error message if number of selected values is less than the min', () => {
     const builder = checkboxGroupBuilder
-      .setValidation(validators.checkbox.minMax({ min: 1, max: 1 }));
+      .setValidation(validators.checkbox.minMax({ min: 1, max: 1 }), 'MinMaxValidation');
 
     const CheckboxGroupType = builder.getType();
 
@@ -42,7 +42,7 @@ describe('CheckboxGroupBuilder', () => {
 
   it('produces an error message if number of selected values more than the max', () => {
     const builder = checkboxGroupBuilder
-      .setValidation(validators.checkbox.minMax({ min: 1, max: 1 }));
+      .setValidation(validators.checkbox.minMax({ min: 1, max: 1 }), 'MinMaxValidation');
 
     const CheckboxGroupType = builder.getType();
 

--- a/src/widgets/__tests__/CheckboxGroupBuilder.spec.js
+++ b/src/widgets/__tests__/CheckboxGroupBuilder.spec.js
@@ -7,7 +7,7 @@ const b = CheckboxBuilder.setLabel('b');
 const c = CheckboxBuilder.setLabel('c');
 
 const checkboxGroupBuilder = CheckboxGroupBuilder
-  .setValidation(validators.checkbox.minMax({ min: 0, max: 2 }), 'MinMaxValidation')
+  .setValidation('MinMaxValidation', validators.checkbox.minMax({ min: 0, max: 2 }))
   .setField('a', a)
   .setField('b', b)
   .setField('c', c);
@@ -15,7 +15,7 @@ const checkboxGroupBuilder = CheckboxGroupBuilder
 describe('CheckboxGroupBuilder', () => {
   it('produces a tcomb Struct that validates correctly', () => {
     const CheckboxGroupType = checkboxGroupBuilder
-      .setValidation(validators.checkbox.minMax({ min: 0, max: 3 }), 'MinMaxValidation')
+      .setValidation('MinMaxValidation', validators.checkbox.minMax({ min: 0, max: 3 }))
       .getType();
     const CheckboxType = CheckboxBuilder.getType();
     const selections = {
@@ -29,7 +29,7 @@ describe('CheckboxGroupBuilder', () => {
 
   it('produces an error message if number of selected values is less than the min', () => {
     const builder = checkboxGroupBuilder
-      .setValidation(validators.checkbox.minMax({ min: 1, max: 1 }), 'MinMaxValidation');
+      .setValidation('MinMaxValidation', validators.checkbox.minMax({ min: 1, max: 1 }));
 
     const CheckboxGroupType = builder.getType();
 
@@ -42,7 +42,7 @@ describe('CheckboxGroupBuilder', () => {
 
   it('produces an error message if number of selected values more than the max', () => {
     const builder = checkboxGroupBuilder
-      .setValidation(validators.checkbox.minMax({ min: 1, max: 1 }), 'MinMaxValidation');
+      .setValidation('MinMaxValidation', validators.checkbox.minMax({ min: 1, max: 1 }));
 
     const CheckboxGroupType = builder.getType();
 


### PR DESCRIPTION
## Changes

We sometimes want to compare two builders for equality; for example, in a React component when deciding if it should update.

To check builders for equality, we can check the internal, immutable state of the builder for equality. That works for all fields except for those that are functions. Two function references will not be equal in two otherwise equivalent builders because the function is redefined when the builder is copied. Tcomb takes the approach of assigning names to types. We use the same approach for functions here. That way, the functions within a builder can be checked for equality by comparing the name of both functions.

Methods that now require a `name` parameter:

- setLazyTemplateFactory
- setValidation
- setTransformer
- setSort
- addValidation
- setType
- setTypeAndValidate (existing name parameter is moved to first position)
- setDispatch

Other changes:

- Remove validation() combinator and replace it with t.refinement calls

## TODO

- [x] Bump package a major version